### PR TITLE
Accurate remaining albums count

### DIFF
--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -22,7 +22,6 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
       // Call the API once to get the total value
 
       logAndSetLoadingMessage(`Requesting saved albums (${offset + limit} / ?)...`)
-
       const response = await spotifyApi.getMySavedAlbums({ limit: limit, offset });
 
       // Use the items to populate album IDs


### PR DESCRIPTION
# PR Summary

## Problem 🤔

We were using a `while(true)` to call Spotify endpoint until all albums had been added, but we didn't know how many there would be and so couldn't surface that info to the user.

## Solution 💡

- Now we're not doing that
- And we do know how many there'll be
- So we can surface that info to the user

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] There are no TODOs in the code without a very good reason 
