### PR TITLE
Remove deletion of non-existent store (keyval)

### DIFF
--- a/src/utilities/indexedDB.js
+++ b/src/utilities/indexedDB.js
@@ -2,8 +2,6 @@ import { openDB } from 'idb';
 
 const dbPromise = openDB('spotify-db', 2, {
   upgrade(db) {
-    db.deleteObjectStore('keyval');
-
     db.createObjectStore('auth');
     db.createObjectStore('data');
   },


### PR DESCRIPTION
Fixed bug where indexedDB would try and remove a non-existent store