### PR TITLE
28 write tests for clicking a genre card

### DIFF
--- a/cypress/e2e/genreCardBehaviour.cy.js
+++ b/cypress/e2e/genreCardBehaviour.cy.js
@@ -1,0 +1,36 @@
+import '../support/commands.js';
+
+describe('GIVEN I visit the app', () => {
+    before(() => {
+        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" });
+        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" });
+        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
+
+        cy.resetIndexedDB().then(() => {
+            cy.setIndexedDBData("spotify-db", "auth", "spotify_code_verifier", "valid_code_verifier");
+            cy.visit('/?code=valid_token&state=valid_state');
+        });
+    });
+
+    it('WHEN I click a genre card \
+             THEN it should expand \
+             WHEN I click it again \
+             THEN it should collapse', () => {
+        cy.visit('/?code=valid_token&state=valid_state');
+
+        cy.get('.genre-grid .genre-section').eq(0).click();
+        cy.get('.genre-grid .genre-section').eq(0).should('have.class', 'expanded');
+
+        cy.get('.genre-grid .genre-section').eq(0).click();
+        cy.get('.genre-grid .genre-section').eq(0).should('have.class', 'collapsed');
+    });
+
+    it('AND the album title and URL are correct', () => {
+        cy.visit('/?code=valid_token&state=valid_state');
+
+        cy.get('.genre-grid .genre-section').eq(0).click();
+        cy.get('.album-name').eq(0).should('contain.text', 'As Days Get Dark');
+        cy.get('.album-link')
+            .should('have.attr', 'href', 'https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J');
+    });
+});

--- a/cypress/e2e/genreCardBehaviour.cy.js
+++ b/cypress/e2e/genreCardBehaviour.cy.js
@@ -20,6 +20,8 @@ describe('GIVEN I visit the app', () => {
 
         cy.get('.genre-grid .genre-section').eq(0).click();
         cy.get('.genre-grid .genre-section').eq(0).should('have.class', 'expanded');
+        cy.get('.genre-grid .genre-section').eq(1).should('have.class', 'collapsed');
+
 
         cy.get('.genre-grid .genre-section').eq(0).click();
         cy.get('.genre-grid .genre-section').eq(0).should('have.class', 'collapsed');

--- a/cypress/e2e/genreCardBehaviour.cy.js
+++ b/cypress/e2e/genreCardBehaviour.cy.js
@@ -1,23 +1,18 @@
-import '../support/commands.js';
-
 describe('GIVEN I visit the app', () => {
-    before(() => {
+    beforeEach(() => {
         cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" });
         cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" });
         cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
 
-        cy.resetIndexedDB().then(() => {
-            cy.setIndexedDBData("spotify-db", "auth", "spotify_code_verifier", "valid_code_verifier");
-            cy.visit('/?code=valid_token&state=valid_state');
-        });
+        cy.resetIndexedDb();
+        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
+        cy.visit('/?code=valid_token&state=valid_state');
     });
 
     it('WHEN I click a genre card \
              THEN it should expand \
              WHEN I click it again \
              THEN it should collapse', () => {
-        cy.visit('/?code=valid_token&state=valid_state');
-
         cy.get('.genre-grid .genre-section').eq(0).click();
         cy.get('.genre-grid .genre-section').eq(0).should('have.class', 'expanded');
         cy.get('.genre-grid .genre-section').eq(1).should('have.class', 'collapsed');
@@ -28,8 +23,6 @@ describe('GIVEN I visit the app', () => {
     });
 
     it('AND the album title and URL are correct', () => {
-        cy.visit('/?code=valid_token&state=valid_state');
-
         cy.get('.genre-grid .genre-section').eq(0).click();
         cy.get('.album-name').eq(0).should('contain.text', 'As Days Get Dark');
         cy.get('.album-link')

--- a/cypress/e2e/userLoginFlow.cy.js
+++ b/cypress/e2e/userLoginFlow.cy.js
@@ -1,3 +1,5 @@
+import '../support/commands.js';
+
 describe('GIVEN I visit the app \
   WHEN I click the login button', () => {
   
@@ -5,6 +7,10 @@ describe('GIVEN I visit the app \
     cy.resetIndexedDb();
     cy.visit('/');
   })
+
+  before(() => {
+    cy.resetIndexedDB();
+  });
 
   it('THEN the login container should load', () => {
     cy.contains('Login with Spotify');

--- a/cypress/e2e/userLoginFlow.cy.js
+++ b/cypress/e2e/userLoginFlow.cy.js
@@ -8,10 +8,6 @@ describe('GIVEN I visit the app \
     cy.visit('/');
   })
 
-  before(() => {
-    cy.resetIndexedDB();
-  });
-
   it('THEN the login container should load', () => {
     cy.contains('Login with Spotify');
   });

--- a/cypress/fixtures/mockGetArtistsResponse.json
+++ b/cypress/fixtures/mockGetArtistsResponse.json
@@ -6,6 +6,13 @@
         "spoken word"
       ],
       "id": "6g8Jqb5JMfv92eB2r0awTN"
+    },
+    {
+      "genres": [
+        "art rock",
+        "alternative rock"
+      ],
+      "id": "4Z8W4fKeB5YxbusRsdQVPb"
     }
   ]
 }

--- a/cypress/fixtures/mockGetMySavedAlbumsResponse.json
+++ b/cypress/fixtures/mockGetMySavedAlbumsResponse.json
@@ -19,7 +19,27 @@
           }
         ]
       }
+    },
+    {
+      "album": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/35UJLpClj5EDrhpNIi4DFg"
+        },
+        "id": "35UJLpClj5EDrhpNIi4DFg",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/ab67616d0000b2739293c743fa542094336c5e12"
+          }
+        ],
+        "name": "The Bends",
+        "artists": [
+          {
+            "id": "4Z8W4fKeB5YxbusRsdQVPb",
+            "name": "Radiohead"
+          }
+        ]
+      }
     }
   ],
-  "total": 26
+  "total": 2
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { authenticateUser, clearAccessToken } from './services/spotifyAuth';
-import { getCachedEntry, clearAllData } from './utilities/indexedDB';
+import { getCachedEntry, clearAllData } from './utilities/indexedDb';
 import './App.css';
 import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -1,5 +1,5 @@
 import { useState, useCallback, useImperativeHandle, forwardRef } from "react";
-import { setCachedEntry, getCachedEntry } from "../../utilities/indexedDB";
+import { setCachedEntry, getCachedEntry } from "../../utilities/indexedDb";
 import { getMySavedAlbums, getArtists } from '../../services/spotifyAPI';
 import logMessage from "../../utilities/loggingConfig";
 

--- a/src/services/spotifyAuth.js
+++ b/src/services/spotifyAuth.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import logMessage from '../utilities/loggingConfig';
-import { setCachedEntry, getCachedEntry } from '../utilities/indexedDB';
+import { setCachedEntry, getCachedEntry } from '../utilities/indexedDb';
 
 const CLIENT_ID = process.env.REACT_APP_SPOTIFY_CLIENT_ID;
 const REDIRECT_URI = window.location.origin;
@@ -38,14 +38,14 @@ export const setAuthUrl = async () => {
 export const authenticateUser = async () => {
   logMessage('Authenticating user...');
 
-  // Check if a token exists in IndexedDB
+  // Check if a token exists in indexedDb
   const cachedToken = await getCachedEntry('auth', 'access_token');
   if (cachedToken) {
     logMessage(`Cached token found: ${cachedToken}`);
     setAccessToken(cachedToken);
   }
 
-  // Check if there’s already a codeVerifier saved in IndexedDB
+  // Check if there’s already a codeVerifier saved in indexedDb
   const existingCodeVerifier = await getCachedEntry('auth', 'spotify_code_verifier');
   const urlParams = new URLSearchParams(window.location.search);
   const code = urlParams.get('code');
@@ -57,7 +57,6 @@ export const authenticateUser = async () => {
     logMessage(`Token: ${token}`);
     setAccessToken(token);
 
-    // Optionally, clear the codeVerifier from IndexedDB after successful exchange
     await setCachedEntry('auth', null, 'spotify_code_verifier');
   }
 
@@ -108,7 +107,6 @@ export const getAuthorizationURL = async () => {
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
 
-  // Save the codeVerifier in IndexedDB
   await setCachedEntry('auth', codeVerifier, 'spotify_code_verifier');
 
   logMessage(`Code verifier: ${codeVerifier}`);

--- a/src/utilities/loggingConfig.js
+++ b/src/utilities/loggingConfig.js
@@ -1,6 +1,6 @@
 // loggingConfig.js
 import AWS from 'aws-sdk';
-import { getCachedEntry, setCachedEntry } from './indexedDB';
+import { getCachedEntry, setCachedEntry } from './indexedDb'
 import { v1 } from 'uuid';
 
 AWS.config.update({ region: 'eu-west-2',


### PR DESCRIPTION
# PR Summary

## Problem 🤔

No e2e tests for what happens when you expand a genre card.

## Solution 💡

Added an e2e test for this behaviour. Initially added this as additional assertions inside `spotifyGenreAlbumDataMapping`, but these ran painfully slow and were otherwise flaky, so decided there's no real harm in separating the behaviour except for a small amount of boilerplate (which we could abstract into a command or util file or something one day).

## PR Review Checklist 📋

- [ ] There are no TODOs in the code without a very good reason
