### PR TITLE
27-write-tests-for-refresh-button

### DIFF
--- a/cypress/e2e/refreshButton.cy.js
+++ b/cypress/e2e/refreshButton.cy.js
@@ -1,0 +1,35 @@
+describe('GIVEN I am on the genre grid page', () => {
+    beforeEach(() => {
+        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse_oneAlbum.json" }).as('getMySavedAlbums');
+        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse_oneArtist.json" }).as('getArtists');
+        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
+        
+        cy.resetIndexedDb();
+        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
+        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+
+        cy.wait("@getMySavedAlbums");
+        cy.wait("@getArtists");
+    });
+
+    it('THEN there should only be one album', () => {
+        cy.get('.genre-grid').children().its('length').should('eq', 1);
+    });
+    
+    describe('WHEN I click the refresh button', () => {
+        beforeEach(() => {
+            cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums_oneAlbum');
+            cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists_oneArtist');
+            
+            cy.get('.refresh-button').click();
+        });
+        
+        it('THEN the genre grid should update', () => {
+            cy.get('.genre-grid').children().its('length').should('eq', 2);
+            cy.get('.genre-grid .genre-section').eq(1).click();
+            cy.get('.album-name').eq(0).should('contain.text', 'The Bends');
+            cy.get('.album-link')
+                .should('have.attr', 'href', 'https://open.spotify.com/album/35UJLpClj5EDrhpNIi4DFg');
+        });
+    });
+});

--- a/cypress/fixtures/mockGetArtistsResponse_oneArtist.json
+++ b/cypress/fixtures/mockGetArtistsResponse_oneArtist.json
@@ -1,0 +1,12 @@
+{
+  "artists": [
+    {
+      "genres": [
+        "slowcore",
+        "spoken word"
+      ],
+      "id": "6g8Jqb5JMfv92eB2r0awTN"
+    }
+  ]
+}
+

--- a/cypress/fixtures/mockGetMySavedAlbumsResponse_oneAlbum.json
+++ b/cypress/fixtures/mockGetMySavedAlbumsResponse_oneAlbum.json
@@ -1,0 +1,25 @@
+{
+  "items": [
+    {
+      "album": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J"
+        },
+        "id": "5jMbGYYNDo0lTyUnKtcm8J",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/ab67616d0000b273c9ac1ea80b4c74c09733bcd3"
+          }
+        ],
+        "name": "As Days Get Dark",
+        "artists": [
+          {
+            "id": "6g8Jqb5JMfv92eB2r0awTN",
+            "name": "Arab Strap"
+          }
+        ]
+      }
+    }
+  ],
+  "total": 1
+}


### PR DESCRIPTION
# PR Summary

## Problem 🤔

No automated tests for refresh button behaviour.

## Solution 💡

* Add new mock responses for a single album/artist pair
* Intercept API calls with single album responses
* Load page
* Intercept API calls with multiple album responses
* Click refresh button and verify that there are now two genres/albums

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] There are no TODOs in the code without a very good reason
