### PR TITLE
30 write tests for search box

### DIFF
--- a/cypress/e2e/authenticatedNavigation.cy.js
+++ b/cypress/e2e/authenticatedNavigation.cy.js
@@ -1,9 +1,5 @@
 beforeEach(() => {
-    cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" });
-    cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" });
-    cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
-    cy.resetIndexedDb();
-    cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
+    cy.mockAPIResponsesAndInitialiseAuthenticatedState();
 });
 
 describe('GIVEN I am on the homepage', () => {

--- a/cypress/e2e/disconnectSpotifyAccount.cy.js
+++ b/cypress/e2e/disconnectSpotifyAccount.cy.js
@@ -35,10 +35,7 @@ describe("GIVEN I have authenticated with Spotify", () => {
             cy.getIndexedDbData('auth', 'session_id').should('exist');
         });
 
-        // TODO: Figure out why this test fails when using `npx cypress run`
         it("THEN my saved albums are removed", () => {
-            // cy.debug();
-            // cy.pause();
             cy.getIndexedDbData('data', 'grouped_albums').should('be.undefined');
         }); 
     });

--- a/cypress/e2e/disconnectSpotifyAccount.cy.js
+++ b/cypress/e2e/disconnectSpotifyAccount.cy.js
@@ -7,9 +7,10 @@ describe("GIVEN I have authenticated with Spotify", () => {
         cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
         cy.visit('/genre-album-map?code=valid_token&state=valid_state');
 
-        cy.wait('@getMySavedAlbums');
-        cy.wait('@getArtists');
-        cy.wait('@authToken');
+        cy.wait(['@getMySavedAlbums', '@getArtists', '@authToken']);
+
+        // Wait for genre grid to load
+        cy.get('.genre-grid').children().its('length').should('eq', 2);
     });
 
     describe("WHEN I click the disconnect Spotify account link", () => {
@@ -27,13 +28,17 @@ describe("GIVEN I have authenticated with Spotify", () => {
             cy.getIndexedDbData('auth', 'access_token').should('be.undefined');
             cy.getIndexedDbData('auth', 'refresh_token').should('be.undefined');
             cy.getIndexedDbData('auth', 'spotify_code_verifier').should('be.undefined');
+
         });
         
         it("THEN my session_id is not removed", () => {
             cy.getIndexedDbData('auth', 'session_id').should('exist');
         });
 
+        // TODO: Figure out why this test fails when using `npx cypress run`
         it("THEN my saved albums are removed", () => {
+            // cy.debug();
+            // cy.pause();
             cy.getIndexedDbData('data', 'grouped_albums').should('be.undefined');
         }); 
     });

--- a/cypress/e2e/disconnectSpotifyAccount.cy.js
+++ b/cypress/e2e/disconnectSpotifyAccount.cy.js
@@ -10,7 +10,7 @@ describe("GIVEN I have authenticated with Spotify", () => {
         cy.wait(['@getMySavedAlbums', '@getArtists', '@authToken']);
 
         // Wait for genre grid to load
-        cy.get('.genre-grid').children().its('length').should('eq', 2);
+        cy.get('.genre-grid').should('exist').and('be.visible');
     });
 
     describe("WHEN I click the disconnect Spotify account link", () => {

--- a/cypress/e2e/disconnectSpotifyAccount.cy.js
+++ b/cypress/e2e/disconnectSpotifyAccount.cy.js
@@ -1,16 +1,6 @@
 describe("GIVEN I have authenticated with Spotify", () => {
     beforeEach(() => {
-        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
-        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
-        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" }).as('authToken');
-        cy.resetIndexedDb();
-        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
-        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
-
-        cy.wait(['@getMySavedAlbums', '@getArtists', '@authToken']);
-
-        // Wait for genre grid to load
-        cy.get('.genre-grid').should('exist').and('be.visible');
+        cy.mockAPIResponsesAndInitialiseAuthenticatedState();
     });
 
     describe("WHEN I click the disconnect Spotify account link", () => {

--- a/cypress/e2e/genreCardBehaviour.cy.js
+++ b/cypress/e2e/genreCardBehaviour.cy.js
@@ -1,12 +1,6 @@
 describe('GIVEN I am on the genre grid page', () => {
     beforeEach(() => {
-        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" });
-        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" });
-        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
-
-        cy.resetIndexedDb();
-        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
-        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+        cy.mockAPIResponsesAndInitialiseAuthenticatedState();
     });
 
     it('WHEN I click a genre card \

--- a/cypress/e2e/refreshButton.cy.js
+++ b/cypress/e2e/refreshButton.cy.js
@@ -1,15 +1,15 @@
 describe('GIVEN I am on the genre grid page', () => {
     beforeEach(() => {
+        // Note: single album and artist responses are used to test the refresh button functionality
         cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse_oneAlbum.json" }).as('getMySavedAlbums');
         cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse_oneArtist.json" }).as('getArtists');
-        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
+        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" }).as('authToken');
         
         cy.resetIndexedDb();
         cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
         cy.visit('/genre-album-map?code=valid_token&state=valid_state');
 
-        cy.wait("@getMySavedAlbums");
-        cy.wait("@getArtists");
+        cy.wait(["@getMySavedAlbums", "@getArtists", "@authToken"]);
     });
 
     it('THEN there should only be one album', () => {

--- a/cypress/e2e/searchBox.cy.js
+++ b/cypress/e2e/searchBox.cy.js
@@ -5,7 +5,7 @@ describe('GIVEN I am on the genre grid page', () => {
         cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
         cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
         cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
-        
+
         cy.resetIndexedDb();
         cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
         cy.visit('/genre-album-map?code=valid_token&state=valid_state');
@@ -22,9 +22,9 @@ describe('GIVEN I am on the genre grid page', () => {
         beforeEach(() => {
             cy.get(`[placeholder="${searchBoxPlaceholder}"]`).click();
             cy.get(`[placeholder="${searchBoxPlaceholder}"]`).type("rock").should('have.value', "rock");
-    
+
         });
-        
+
         it('THEN the genre grid should be filtered', () => {
             cy.get('.genre-grid').should('exist');
 
@@ -33,36 +33,26 @@ describe('GIVEN I am on the genre grid page', () => {
             cy.get('.genre-grid .genre-section').eq(0).click();
             cy.get('.album-name').eq(0).should('contain.text', 'The Bends');
             cy.get('.album-link')
-            .should('have.attr', 'href', 'https://open.spotify.com/album/35UJLpClj5EDrhpNIi4DFg');
+                .should('have.attr', 'href', 'https://open.spotify.com/album/35UJLpClj5EDrhpNIi4DFg');
         });
     });
-});
 
-describe('WHEN I clear the search box', () => {
-    beforeEach(() => {
-        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
-        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
-        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
-        
-        cy.resetIndexedDb();
-        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
-        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+    describe('WHEN I clear the search box', () => {
+        beforeEach(() => {
+            cy.get(`[placeholder="${searchBoxPlaceholder}"]`).click();
+            cy.get(`[placeholder="${searchBoxPlaceholder}"]`).type("rock").should('have.value', "rock");
+            cy.get(`[placeholder="${searchBoxPlaceholder}"]`).clear().should('have.value', '');
+        });
 
-        cy.wait(["@getMySavedAlbums", "@getArtists"]);
+        it('THEN the genre grid should be reset', () => {
+            cy.get('.genre-grid').should('exist');
 
-        cy.get(`[placeholder="${searchBoxPlaceholder}"]`).click();
-        cy.get(`[placeholder="${searchBoxPlaceholder}"]`).type("rock").should('have.value', "rock");
-        cy.get(`[placeholder="${searchBoxPlaceholder}"]`).clear().should('have.value', '');
-    });
+            cy.get('.genre-grid').children().its('length').should('eq', 2);
 
-    it('THEN the genre grid should be reset', () => {
-        cy.get('.genre-grid').should('exist');
-
-        cy.get('.genre-grid').children().its('length').should('eq', 2);
-
-        cy.get('.genre-grid .genre-section').eq(0).click();
-        cy.get('.album-name').eq(0).should('contain.text', 'As Days Get Dark');
-        cy.get('.album-link')
-            .should('have.attr', 'href', 'https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J');
+            cy.get('.genre-grid .genre-section').eq(0).click();
+            cy.get('.album-name').eq(0).should('contain.text', 'As Days Get Dark');
+            cy.get('.album-link')
+                .should('have.attr', 'href', 'https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J');
+        });
     });
 });

--- a/cypress/e2e/searchBox.cy.js
+++ b/cypress/e2e/searchBox.cy.js
@@ -1,0 +1,68 @@
+const searchBoxPlaceholder = 'Search genres, albums, and artists...';
+
+describe('GIVEN I am on the genre grid page', () => {
+    beforeEach(() => {
+        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
+        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
+        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
+        
+        cy.resetIndexedDb();
+        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
+        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+
+        cy.wait(["@getMySavedAlbums", "@getArtists"]);
+    });
+
+    it('THEN there should be an empty search box', () => {
+        cy.get(`[placeholder="${searchBoxPlaceholder}"]`).should('exist');
+        cy.get(`[placeholder="${searchBoxPlaceholder}"]`).should('have.value', '');
+    });
+
+    describe('WHEN I type in the search box', () => {
+        beforeEach(() => {
+            cy.get(`[placeholder="${searchBoxPlaceholder}"]`).click();
+            cy.get(`[placeholder="${searchBoxPlaceholder}"]`).type("rock").should('have.value', "rock");
+    
+        });
+        
+        it('THEN the genre grid should be filtered', () => {
+            cy.get('.genre-grid').should('exist');
+
+            cy.get('.genre-grid').children().its('length').should('eq', 1);
+
+            cy.get('.genre-grid .genre-section').eq(0).click();
+            cy.get('.album-name').eq(0).should('contain.text', 'The Bends');
+            cy.get('.album-link')
+            .should('have.attr', 'href', 'https://open.spotify.com/album/35UJLpClj5EDrhpNIi4DFg');
+        });
+    });
+});
+
+describe('WHEN I clear the search box', () => {
+    beforeEach(() => {
+        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
+        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
+        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
+        
+        cy.resetIndexedDb();
+        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
+        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+
+        cy.wait(["@getMySavedAlbums", "@getArtists"]);
+
+        cy.get(`[placeholder="${searchBoxPlaceholder}"]`).click();
+        cy.get(`[placeholder="${searchBoxPlaceholder}"]`).type("rock").should('have.value', "rock");
+        cy.get(`[placeholder="${searchBoxPlaceholder}"]`).clear().should('have.value', '');
+    });
+
+    it('THEN the genre grid should be reset', () => {
+        cy.get('.genre-grid').should('exist');
+
+        cy.get('.genre-grid').children().its('length').should('eq', 2);
+
+        cy.get('.genre-grid .genre-section').eq(0).click();
+        cy.get('.album-name').eq(0).should('contain.text', 'As Days Get Dark');
+        cy.get('.album-link')
+            .should('have.attr', 'href', 'https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J');
+    });
+});

--- a/cypress/e2e/searchBox.cy.js
+++ b/cypress/e2e/searchBox.cy.js
@@ -2,15 +2,7 @@ const searchBoxPlaceholder = 'Search genres, albums, and artists...';
 
 describe('GIVEN I am on the genre grid page', () => {
     beforeEach(() => {
-        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
-        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
-        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
-
-        cy.resetIndexedDb();
-        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
-        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
-
-        cy.wait(["@getMySavedAlbums", "@getArtists"]);
+        cy.mockAPIResponsesAndInitialiseAuthenticatedState();
     });
 
     it('THEN there should be an empty search box', () => {

--- a/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
+++ b/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
@@ -1,13 +1,6 @@
 describe('GIVEN I have authenticated', () => {
     beforeEach(() => {
-        cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" });
-        cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" });
-        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" });
-        
-        cy.resetIndexedDb();
-        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
-        
-        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+        cy.mockAPIResponsesAndInitialiseAuthenticatedState();
     })
     
     it('THEN the header should load', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,10 +7,26 @@ Cypress.Commands.add('resetIndexedDb', () => {
     cy.getIndexedDb('@spotify-db').createObjectStore('data').as('data');
 });
 
-Cypress.Commands.add('setIndexedDbData', (store,key,value) => {
+Cypress.Commands.add('setIndexedDbData', (store, key, value) => {
     cy.getStore(`@${store}`).createItem(`${key}`, `${value}`);
 });
 
-Cypress.Commands.add('getIndexedDbData', (store,key) => {
+Cypress.Commands.add('getIndexedDbData', (store, key) => {
     cy.getStore(`@${store}`).readItem(`${key}`);
+});
+
+Cypress.Commands.add('mockAPIResponsesAndInitialiseAuthenticatedState', () => {
+    cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
+    cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
+    cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" }).as('authToken');
+
+    cy.resetIndexedDb();
+    cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
+
+    cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+
+    cy.wait(["@getMySavedAlbums", "@getArtists", "@authToken"]);
+
+    // Wait for genre grid to load
+    cy.get('.genre-grid').should('exist').and('be.visible');
 });

--- a/src/utilities/loggingConfig.js
+++ b/src/utilities/loggingConfig.js
@@ -1,4 +1,3 @@
-// loggingConfig.js
 import AWS from 'aws-sdk';
 import { getCachedEntry, setCachedEntry } from './indexedDb'
 import { v1 } from 'uuid';


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* No tests for search box functionality

### Also fixed in this PR:
* Race condition when disconnecting Spotify account causes intermittent test failures
* All tests use the same initialisation logic

## Solution 💡

* GIVEN I am on the genre grid page
  * THEN there should be an empty search box
  * WHEN I type in the search box
    * THEN the genre grid should be filtered
  * WHEN I clear the search box
    * THEN the genre grid should be reset

### Also fixed in this PR:
* In `cypress\e2e\disconnectSpotifyAccount.cy.js`, wait for the genre grid to load before disconnecting Spotify account
* Move common initialisation logic to a shared function

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written 
- [x] There are no TODOs in the code without a very good reason
