### PR TITLE
Extend searchBox to include tests for sorting genre grid

### DIFF
--- a/cypress/e2e/searchAndSortGenreGrid.cy.js
+++ b/cypress/e2e/searchAndSortGenreGrid.cy.js
@@ -43,4 +43,23 @@ describe('GIVEN I am on the genre grid page', () => {
                 .should('have.attr', 'href', 'https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J');
         });
     });
+
+    it('THEN there should be a sorting dropdown', () => {
+        cy.get('.sort-dropdown').should('exist');
+        cy.get('.sort-dropdown').should('have.value', 'number-desc');
+    });
+
+    describe('WHEN I change the sorting dropdown', () => {
+        beforeEach(() => {
+            cy.get('.sort-dropdown').select('alphabetical-asc');
+        });
+
+        it('THEN the genre grid should be sorted', () => {
+            cy.get('.genre-grid').children().its('length').should('eq', 2);
+
+            cy.get('.genre-grid .genre-section').first()
+                .find('.genre-title')
+                .should('have.text', 'art rock, alternative rock');
+        });
+    });
 });

--- a/cypress/e2e/searchAndSortGenreGrid.cy.js
+++ b/cypress/e2e/searchAndSortGenreGrid.cy.js
@@ -49,17 +49,31 @@ describe('GIVEN I am on the genre grid page', () => {
         cy.get('.sort-dropdown').should('have.value', 'number-desc');
     });
 
-    describe('WHEN I change the sorting dropdown', () => {
+    describe('WHEN I sort alphabetically', () => {
         beforeEach(() => {
             cy.get('.sort-dropdown').select('alphabetical-asc');
         });
 
-        it('THEN the genre grid should be sorted', () => {
+        it('THEN the genre grid should be sorted alphabetically', () => {
             cy.get('.genre-grid').children().its('length').should('eq', 2);
 
             cy.get('.genre-grid .genre-section').first()
                 .find('.genre-title')
                 .should('have.text', 'art rock, alternative rock');
+        });
+    });
+
+    describe('WHEN I sort reverse alphabetically', () => {
+        beforeEach(() => {
+            cy.get('.sort-dropdown').select('alphabetical-desc');
+        });
+
+        it('THEN the genre grid should be sorted reverse alphabetically', () => {
+            cy.get('.genre-grid').children().its('length').should('eq', 2);
+
+            cy.get('.genre-grid .genre-section').first()
+                .find('.genre-title')
+                .should('have.text', 'slowcore, spoken word');
         });
     });
 });


### PR DESCRIPTION
# PR Summary

## Problem 🤔

No tests for sorting the genre grid

## Solution 💡

Set the dropdown to sort alphabetically, and assert genre grid is sorted correctly.
Then, reverse  and assert that the sort order is reversed.

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written 
- [x] There are no TODOs in the code without a very good reason
