### PR TITLE
33 test bad response from spotify auth api

### DIFF
--- a/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
+++ b/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
@@ -1,22 +1,85 @@
-describe('GIVEN I have authenticated', () => {
+// Helper functions
+const assertErrorMessage = () => {
+    cy.get('.error-title').should('contain', 'Something went wrong.')
+        .and('contain', 'This has been reported to the developers.');
+    cy.get('.error-message').should('contain', 'Request failed with status code 400')
+        .and('contain', 'Internal server error');
+    cy.get('.error-button').should('exist').and('contain', 'Try Again');
+};
+
+const interceptAuthTokenError = () => {
+    cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', {
+        statusCode: 400,
+        body: { message: 'Internal server error' }
+    }).as('authTokenError');
+};
+
+const interceptSuccessfulAuth = () => {
+    cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" }).as('authToken');
+    cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
+    cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
+};
+
+// Test cases
+describe('GIVEN I authenticate successfully', () => {
     beforeEach(() => {
         cy.mockAPIResponsesAndInitialiseAuthenticatedState();
-    })
-    
+    });
+
     it('THEN the header should load', () => {
         cy.contains('Your album library');
-        
         cy.get('.menu-button').should('exist');
         cy.get('.refresh-button').should('exist');
         cy.get('.search-sort-container').should('exist');
-    })
-    
+    });
+
     it('AND the genre grid should load', () => {
         cy.get('.genre-grid').should('exist');
-    }) 
-    
-    it('AND the album data should load', () => { 
+    });
+
+    it('AND the album data should load', () => {
         cy.get('.genre-grid .genre-section .genre-title').should('contain', 'slowcore, spoken word');
-        cy.get('.genre-grid .genre-section .album-preview img').should('have.attr', 'src').should('include', 'https://i.scdn.co/image/ab67616d0000b273c9ac1ea80b4c74c09733bcd3');
-    }) 
+        cy.get('.genre-grid .genre-section .album-preview img').should('have.attr', 'src')
+            .should('include', 'https://i.scdn.co/image/ab67616d0000b273c9ac1ea80b4c74c09733bcd3');
+    });
+});
+
+describe('GIVEN the token exchange proxy returns an error', () => {
+    beforeEach(() => {
+        Cypress.on('uncaught:exception', () => false);
+        interceptAuthTokenError();
+        cy.resetIndexedDb();
+        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
+        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+        cy.wait(["@authTokenError"]);
+    });
+
+    it('THEN the error message should load', () => {
+        assertErrorMessage();
+    });
+
+    describe('WHEN I try again unsuccessfully', () => {
+        beforeEach(() => {
+            cy.get('.error-button').click();
+            cy.wait(["@authTokenError"]);
+        });
+
+        it('THEN the error message should load', () => {
+            assertErrorMessage();
+        });
+    });
+
+    describe('WHEN I try again successfully', () => {
+        beforeEach(() => {
+            interceptSuccessfulAuth();
+            cy.get('.error-button').click();
+            cy.wait(["@authToken", "@getMySavedAlbums", "@getArtists"]);
+        });
+
+        it('THEN the genre grid should load', () => {
+            cy.get('.page-title').should('contain', 'Your album library');
+            cy.get('.refresh-button').should('exist');
+            cy.get('.genre-grid').should('exist');
+        });
+    });
 });

--- a/cypress/fixtures/mockAuthTokenResponse.json
+++ b/cypress/fixtures/mockAuthTokenResponse.json
@@ -1,7 +1,5 @@
 {
-  "body": {
-    "access_token": "valid_access_token",
-    "expires_in": 3600,
-    "refresh_token": "valid_refresh_token"
-  }
+  "access_token": "valid_access_token",
+  "expires_in": 3600,
+  "refresh_token": "valid_refresh_token"
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -16,16 +16,16 @@ Cypress.Commands.add('getIndexedDbData', (store, key) => {
 });
 
 Cypress.Commands.add('mockAPIResponsesAndInitialiseAuthenticatedState', () => {
+    cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" }).as('authToken');
     cy.intercept('GET', 'https://api.spotify.com/v1/me/albums*', { fixture: "mockGetMySavedAlbumsResponse.json" }).as('getMySavedAlbums');
     cy.intercept('GET', 'https://api.spotify.com/v1/artists*', { fixture: "mockGetArtistsResponse.json" }).as('getArtists');
-    cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" }).as('authToken');
 
     cy.resetIndexedDb();
     cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
 
     cy.visit('/genre-album-map?code=valid_token&state=valid_state');
 
-    cy.wait(["@getMySavedAlbums", "@getArtists", "@authToken"]);
+    cy.wait(["@authToken", "@getMySavedAlbums", "@getArtists"]);
 
     // Wait for genre grid to load
     cy.get('.genre-grid').should('exist').and('be.visible');

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,10 @@ function Root() {
         <h1 className="error-title">
           Something went wrong. <br />
           This has been reported to the developers.</h1>
-        <p className="error-message">{error.message}</p>
+        <p className="error-message">
+          {error?.message || ''} <br/>
+          {error?.response?.data?.message || ''}
+        </p>
         <button 
           className="error-button" 
           onClick={async () => {


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* No tests for unhappy path when communicating with the token exchange proxy

## Solution 💡

* Mock a failed response using `statusCode: 400`
* Assert that the error fallback component is shown
* Assert that - if left untouched - it fails again when retried
* Assert that - if the problem is 'resolved' - it succeeds on second attempt when retried

### Also fixed in this PR

* Amended a test that was broken by #70 

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written 
- [x] There are no TODOs in the code without a very good reason
