### PR TITLE
44 test bad response from spotify data api

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,6 +3,6 @@ const { defineConfig } = require('cypress');
 module.exports = defineConfig({
   projectId: '5te4qf',
   e2e: {
-    baseUrl: 'http://localhost:3000', // Update with your app's URL
+    baseUrl: 'http://localhost:3000', 
   },
 });

--- a/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
+++ b/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
@@ -7,11 +7,11 @@ const assertErrorMessage = () => {
     cy.get('.error-button').should('exist').and('contain', 'Try Again');
 };
 
-const interceptAuthTokenError = () => {
-    cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', {
+const interceptWithError = (method, url, alias) => {
+    cy.intercept(method, url, {
         statusCode: 400,
         body: { message: 'Internal server error' }
-    }).as('authTokenError');
+    }).as(alias);
 };
 
 const interceptSuccessfulAuth = () => {
@@ -32,28 +32,71 @@ describe('GIVEN I authenticate successfully', () => {
         cy.get('.refresh-button').should('exist');
         cy.get('.search-sort-container').should('exist');
     });
-
+    
     it('AND the genre grid should load', () => {
         cy.get('.genre-grid').should('exist');
     });
-
+    
     it('AND the album data should load', () => {
         cy.get('.genre-grid .genre-section .genre-title').should('contain', 'slowcore, spoken word');
         cy.get('.genre-grid .genre-section .album-preview img').should('have.attr', 'src')
-            .should('include', 'https://i.scdn.co/image/ab67616d0000b273c9ac1ea80b4c74c09733bcd3');
+        .should('include', 'https://i.scdn.co/image/ab67616d0000b273c9ac1ea80b4c74c09733bcd3');
     });
 });
 
 describe('GIVEN the token exchange proxy returns an error', () => {
     beforeEach(() => {
         Cypress.on('uncaught:exception', () => false);
-        interceptAuthTokenError();
+        interceptWithError('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', 'authTokenError');
         cy.resetIndexedDb();
         cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
         cy.visit('/genre-album-map?code=valid_token&state=valid_state');
         cy.wait(["@authTokenError"]);
     });
+    
+    it('THEN the error message should load', () => {
+        assertErrorMessage();
+    });
+    
+    describe('WHEN I try again unsuccessfully', () => {
+        beforeEach(() => {
+            cy.get('.error-button').click();
+            cy.wait(["@authTokenError"]);
+        });
+        
+        it('THEN the error message should load', () => {
+            assertErrorMessage();
+        });
+    });
+    
+    describe('WHEN I try again successfully', () => {
+        beforeEach(() => {
+            interceptSuccessfulAuth();
+            cy.get('.error-button').click();
+            cy.wait(["@authToken", "@getMySavedAlbums", "@getArtists"]);
+        });
+        
+        it('THEN the genre grid should load', () => {
+            cy.get('.page-title').should('contain', 'Your album library');
+            cy.get('.refresh-button').should('exist');
+            cy.get('.genre-grid').should('exist');
+        });
+    });
+});
 
+describe('GIVEN the Spotify API returns an error', () => {
+    beforeEach(() => {
+        Cypress.on('uncaught:exception', () => false);
+        cy.intercept('POST', 'https://9kr3sn67ag.execute-api.eu-west-2.amazonaws.com/*', { fixture: "mockAuthTokenResponse.json" }).as('authToken');
+        interceptWithError('GET', 'https://api.spotify.com/v1/me/albums*', 'albumsError');
+        
+        cy.resetIndexedDb();
+        cy.setIndexedDbData("auth", "spotify_code_verifier", "valid_code_verifier");
+        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+        
+        cy.wait(["@albumsError"]);
+    });
+    
     it('THEN the error message should load', () => {
         assertErrorMessage();
     });
@@ -61,21 +104,21 @@ describe('GIVEN the token exchange proxy returns an error', () => {
     describe('WHEN I try again unsuccessfully', () => {
         beforeEach(() => {
             cy.get('.error-button').click();
-            cy.wait(["@authTokenError"]);
+            cy.wait(["@albumsError"]);
         });
-
+        
         it('THEN the error message should load', () => {
             assertErrorMessage();
         });
     });
-
+    
     describe('WHEN I try again successfully', () => {
         beforeEach(() => {
             interceptSuccessfulAuth();
             cy.get('.error-button').click();
             cy.wait(["@authToken", "@getMySavedAlbums", "@getArtists"]);
         });
-
+        
         it('THEN the genre grid should load', () => {
             cy.get('.page-title').should('contain', 'Your album library');
             cy.get('.refresh-button').should('exist');

--- a/src/index.css
+++ b/src/index.css
@@ -13,14 +13,13 @@ code {
 }
 
 .error-fallback {
-  display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
   text-align: center;
-  color: #ffffff;
+  color: #FFFFFF;
   background-color: #121212;
+  padding-top: 50px;
 }
 
 .error-title {

--- a/src/index.js
+++ b/src/index.js
@@ -7,52 +7,9 @@ import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import StackTrace from 'stacktrace-js';
 import { BrowserRouter as Router } from 'react-router-dom';
 import logMessage from './utilities/loggingConfig';
+import { ErrorFallback, handleError } from './utilities/errorHandling';
 
 function Root() {
-
-  function ErrorFallback({ error, resetErrorBoundary }) {
-    const [isLoading, setIsLoading] = useState(false);
-
-    return (
-      <div className="error-fallback">
-        {isLoading && (
-          <div className="loading-overlay">
-            <div className="spinner"></div>
-          </div>
-        )}
-        <h1 className="error-title">
-          Something went wrong. <br />
-          This has been reported to the developers.</h1>
-        <p className="error-message">
-          {error?.message || ''} <br/>
-          {error?.response?.data?.message || ''}
-        </p>
-        <button 
-          className="error-button" 
-          onClick={async () => {
-            if (!isLoading) {
-              setIsLoading(true);
-              logMessage('User reset the error boundary.');
-              await new Promise(r => setTimeout(r, 2000));
-              resetErrorBoundary();
-            }
-          }}
-          disabled={isLoading}
-        >
-          {isLoading ? 'Loading...' : 'Try Again'}
-        </button>
-      </div>
-    );
-  }
-
-  function handleError(error, info) {
-    StackTrace.fromError(error).then((stackframes) => {
-      const stackString = stackframes
-        .map((sf) => `${sf.functionName || 'anonymous'} (${sf.fileName}:${sf.lineNumber}:${sf.columnNumber})`)
-        .join('\n');
-      logMessage(`A fatal error occurred with error: ${error} and traceback:\n${stackString}`);
-    });
-  }
 
   return (
     <React.StrictMode>

--- a/src/utilities/errorHandling.js
+++ b/src/utilities/errorHandling.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import StackTrace from 'stacktrace-js';
+import logMessage from '../utilities/loggingConfig';
+
+export function ErrorFallback({ error, resetErrorBoundary }) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <div className="error-fallback">
+      {isLoading && (
+        <div className="loading-overlay">
+          <div className="spinner"></div>
+        </div>
+      )}
+      <h1 className="error-title">
+        Something went wrong. <br />
+        This has been reported to the developers.</h1>
+      <p className="error-message">
+        {error?.message || ''} <br/>
+        {error?.response?.data?.message || ''}
+      </p>
+      <button 
+        className="error-button" 
+        onClick={async () => {
+          if (!isLoading) {
+            setIsLoading(true);
+            logMessage('User reset the error boundary.');
+            await new Promise(r => setTimeout(r, 2000));
+            resetErrorBoundary();
+          }
+        }}
+        disabled={isLoading}
+      >
+        {isLoading ? 'Loading...' : 'Try Again'}
+      </button>
+    </div>
+  );
+}
+
+export function handleError(error) {
+  StackTrace.fromError(error).then((stackframes) => {
+    const stackString = stackframes
+      .map((sf) => `${sf.functionName || 'anonymous'} (${sf.fileName}:${sf.lineNumber}:${sf.columnNumber})`)
+      .join('\n');
+    logMessage(`A fatal error occurred with error: ${error} and traceback:\n${stackString}`);
+  });
+}


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* No tests for unhappy path when interacting with Spotify API

## Solution 💡

* Extend existing tests for token exchange proxy to also attempt the artists and albums endpoint
* Again, also test that "Try Again" fails again...
* ... unless the endpoints succeed on second try, in which case the component successfully loads

### Also fixed in this PR:

* Authorisation has been completely refactored into the genre grid container
* ErrorFallback component and HandleError function are in their own file and imported when needed
* Errors are contained within the component instead of taking over the entire app

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written 
- [x] There are no TODOs in the code without a very good reason
