### PR TITLE
45 add header privacy policy and about page to login screen

### DIFF
--- a/cypress/e2e/authenticatedNavigation.cy.js
+++ b/cypress/e2e/authenticatedNavigation.cy.js
@@ -127,3 +127,15 @@ describe('GIVEN my location is empty', () => {
         cy.get('.genre-grid').should('exist');
     });
 });
+
+describe('GIVEN I navigate to /authenticate', () => {
+    beforeEach(() => {
+        cy.visit('/authenticate');
+    });
+
+    it('THEN the genre grid should be shown', () => {
+        cy.get('.page-title').should('contain', 'Your album library');
+        cy.get('.refresh-button').should('exist');
+        cy.get('.genre-grid').should('exist');
+    });
+});

--- a/cypress/e2e/authenticatedNavigation.cy.js
+++ b/cypress/e2e/authenticatedNavigation.cy.js
@@ -19,6 +19,18 @@ describe('GIVEN I am on the homepage', () => {
             cy.get('.privacy-policy-container').should('exist');
         });
     });
+    describe('WHEN I open the hamburger menu about link', () => {
+        beforeEach(() => {
+            cy.get('.menu-button').click();
+            cy.get('.menu-item-button').contains('About').click();
+        });
+
+        it('THEN the about page should be displayed', () => {
+            cy.get('.page-title').should('contain', 'About');
+            cy.get('.home-button').should('exist');
+            cy.get('.about-container').should('exist');
+        });
+    });
 
     describe('WHEN I click outside the hamburger menu', () => {
         beforeEach(() => {
@@ -31,7 +43,6 @@ describe('GIVEN I am on the homepage', () => {
             cy.get('.menu-button').click();
         });
     });
-    
     
     describe('WHEN I click the close menu button', () => {
         beforeEach(() => {

--- a/cypress/e2e/unauthenticatedNavigation.cy.js
+++ b/cypress/e2e/unauthenticatedNavigation.cy.js
@@ -35,6 +35,18 @@ describe('GIVEN I am on the privacy policy page', () => {
     });
 });
 
+describe('GIVEN I am on the about page', () => {
+    beforeEach(() => {
+        cy.visit('/about');
+    });
+
+    it('THEN the about page should be displayed', () => {    
+        cy.get('.page-title').should('contain', 'About');
+        cy.get('.home-button').should('exist');
+        cy.get('.about-container').should('exist');
+    });
+});
+
 const paths = [
     '/',
     '/genre-album-map',

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link href="https://fonts.googleapis.com/css2?family=ABeeZee&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Helvetica%20Neue&display=swap" rel="stylesheet">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { ErrorBoundary, useErrorBoundary } from "react-error-boundary";
 import { ErrorFallback, handleError } from './utilities/errorHandling';
 import { clearAccessToken } from './services/spotifyAuth';
-import { getCachedEntry, clearAllData } from './utilities/indexedDb';
+import { clearAllData } from './utilities/indexedDb';
 import './App.css';
 import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
@@ -11,6 +11,7 @@ import LoginContainer from './containers/loginContainer/loginContainer';
 import HeaderContainer from './containers/headerContainer/headerContainer';
 import GenreGridContainer from './containers/genreGridContainer/genreGridContainer';
 import PrivacyPolicyContainer from './containers/privacyPolicyContainer/privacyPolicyContainer';
+import AboutContainer from './containers/aboutContainer/aboutContainer';
 import ModalContainer from './containers/modalContainer/modalContainer';
 import useModal from './hooks/useModal';
 import { Route, Routes } from "react-router-dom";
@@ -113,6 +114,7 @@ function App() {
           <Route path="/authenticate" element={<LoginContainer />} />
           <Route path="/genre-album-map" element={<GenreGridContainer searchQuery={searchQuery} sortOption={sortOption} ref={genreGridRef} />} />
           <Route path="/privacy-policy" element={<PrivacyPolicyContainer />} />
+          <Route path="/about" element={<AboutContainer />} />
         </Routes>
       </ErrorBoundary>
 

--- a/src/containers/aboutContainer/aboutContainer.js
+++ b/src/containers/aboutContainer/aboutContainer.js
@@ -1,0 +1,32 @@
+import './aboutContainer.css';
+
+const AboutContainer = () => {
+    return (
+        <div className="about-container">
+            <h1>About Spotify Genre Browser</h1>
+            <p>
+                Spotify Genre Browser is a web application that helps you explore your saved albums on Spotify by grouping them into genres. 
+                It provides an intuitive interface to navigate through your music library and discover patterns in your listening habits.
+            </p>
+            <h2>Features</h2>
+            <ul>
+                <li>View your saved albums categorized by genres.</li>
+                <li>Search for specific genres, albums, or artists.</li>
+                <li>Sort genres by name or the number of albums.</li>
+                <li>Seamlessly integrate with Spotify for real-time updates.</li>
+                <li>Disconnect your Spotify account at any time, ensuring your data is wiped locally.</li>
+            </ul>
+            <h2>Privacy</h2>
+            <p>
+                Your privacy is our priority. The app does not collect or store any personal data beyond what is necessary for its functionality. 
+                All logs are anonymized and stored securely.
+            </p>
+            <h2>Get Started</h2>
+            <p>
+                To begin, log in with your Spotify account and start exploring your music library in a whole new way!
+            </p>
+        </div>
+    );
+};
+
+export default AboutContainer;

--- a/src/containers/aboutContainer/aboutContainer.js
+++ b/src/containers/aboutContainer/aboutContainer.js
@@ -1,5 +1,3 @@
-import './aboutContainer.css';
-
 const AboutContainer = () => {
     return (
         <div className="about-container">

--- a/src/containers/headerContainer/headerContainer.js
+++ b/src/containers/headerContainer/headerContainer.js
@@ -7,7 +7,7 @@ import { useNavigationHelpers } from '../../utilities/navigationHelpers';
 
 function HeaderContainer({ onRefresh, onSearch, onSortChange, onOpenDisconnectModal, toggleMenu }) {
     const location = useLocation();
-    const { goTo } = useNavigationHelpers();
+    const { goTo, checkAuthAndNavigate } = useNavigationHelpers();
 
     const handleOpenDisconnectModal = () => {
         onOpenDisconnectModal();
@@ -21,7 +21,7 @@ function HeaderContainer({ onRefresh, onSearch, onSortChange, onOpenDisconnectMo
                         <FontAwesomeIcon icon={faBars} />
                     </button>
                     <h1 className="page-title">Privacy policy</h1>
-                    <button className="home-button" onClick={() => goTo("/genre-album-map")}>
+                    <button className="home-button" onClick={() => checkAuthAndNavigate()}>
                         <FontAwesomeIcon icon={faHouse} />
                     </button>
                 </div>

--- a/src/containers/headerContainer/headerContainer.js
+++ b/src/containers/headerContainer/headerContainer.js
@@ -21,7 +21,7 @@ function HeaderContainer({ onRefresh, onSearch, onSortChange, onOpenDisconnectMo
                         <FontAwesomeIcon icon={faBars} />
                     </button>
                     <h1 className="page-title">Privacy policy</h1>
-                    <button className="home-button" onClick={() => checkAuthAndNavigate()}>
+                    <button className="home-button" onClick={async () => await checkAuthAndNavigate()}>
                         <FontAwesomeIcon icon={faHouse} />
                     </button>
                 </div>

--- a/src/containers/headerContainer/headerContainer.js
+++ b/src/containers/headerContainer/headerContainer.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import './headerContainer.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSyncAlt, faBars, faHouse } from '@fortawesome/free-solid-svg-icons';
+import { faSyncAlt, faBars, faHouse, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import { useLocation } from "react-router-dom";
 import { useNavigationHelpers } from '../../utilities/navigationHelpers';
 
@@ -53,6 +53,36 @@ function HeaderContainer({ onRefresh, onSearch, onSortChange, onOpenDisconnectMo
                         <option value="number-asc">Size (Asc)</option>
                         <option value="number-desc">Size (Desc)</option>
                     </select>
+                </div>
+            </div>
+        );
+    }
+    else if (location.pathname === '/about') {
+        return (
+            <div className="header-container">
+                <div className="title-container">
+                    <button className="menu-button" onClick={toggleMenu}>
+                        <FontAwesomeIcon icon={faBars} />
+                    </button>
+                    <h1 className="page-title">About</h1>
+                    <button className="home-button" onClick={() => checkAuthAndNavigate()}>
+                        <FontAwesomeIcon icon={faHouse} />
+                    </button>
+                </div>
+            </div>
+        );
+    }
+    else if (location.pathname) {
+        return (
+            <div className="header-container">
+                <div className="title-container">
+                    <button className="menu-button" onClick={toggleMenu}>
+                        <FontAwesomeIcon icon={faBars} />
+                    </button>
+                    <h1 className="page-title">Authentication</h1>
+                    <button className="refresh-button" onClick={() => goTo("/about")}>
+                        <FontAwesomeIcon icon={faCircleInfo} />
+                    </button>
                 </div>
             </div>
         );

--- a/src/containers/loginContainer/loginContainer.js
+++ b/src/containers/loginContainer/loginContainer.js
@@ -1,11 +1,22 @@
 import { useEffect } from "react";
 import { setAuthUrl } from "../../services/spotifyAuth";
+import { getCachedEntry } from "../../utilities/indexedDb";
+import { useNavigationHelpers } from "../../utilities/navigationHelpers";
 
 function LoginContainer() {
+
+  const { goTo } = useNavigationHelpers();
 
   useEffect(() => {
     window.redirectToSpotifyAuth = function () {
       setAuthUrl();
+    }
+  }, []);
+
+  useEffect(() => {
+    const token = getCachedEntry('auth', 'access_token');
+    if (token) {
+      goTo('/genre-album-map');
     }
   }, []);
 

--- a/src/containers/loginContainer/loginContainer.js
+++ b/src/containers/loginContainer/loginContainer.js
@@ -14,10 +14,14 @@ function LoginContainer() {
   }, []);
 
   useEffect(() => {
-    const token = getCachedEntry('auth', 'access_token');
-    if (token) {
-      goTo('/genre-album-map');
+    async function checkAuthAndRedirect() {
+      const token = await getCachedEntry('auth', 'access_token');
+      if (token) {
+        goTo('/genre-album-map');
+      }
     }
+
+    checkAuthAndRedirect();
   }, []);
 
   return (

--- a/src/containers/overlayMenu/overlayMenu.js
+++ b/src/containers/overlayMenu/overlayMenu.js
@@ -27,6 +27,11 @@ const OverlayMenu = forwardRef(({ isOpen, toggleMenu, onDisconnect, onDisplayPri
                         </button>
                     </li>
                     <li className="menu-item">
+                        <button className="menu-item-button" onClick={() => handleNavigation("/about")}>
+                            About
+                        </button>
+                    </li>
+                    <li className="menu-item">
                         <button className="menu-item-button" onClick={() => handleNavigation("/privacy-policy")}>
                             Privacy Policy
                         </button>

--- a/src/services/spotifyAPI.js
+++ b/src/services/spotifyAPI.js
@@ -1,9 +1,9 @@
-import { getAccessToken } from './spotifyAuth';
+import { getOrGenerateNewAccessToken } from './spotifyAuth';
 import axios from 'axios';
 import { logMessage } from '../utilities/loggingConfig';
 
 export const getMySavedAlbums = async (limit, offset) => {
-    const token = await getAccessToken();
+    const token = await getOrGenerateNewAccessToken();
     if (!token) {
       throw new Error('Access token not found.');
     }
@@ -26,7 +26,7 @@ export const getMySavedAlbums = async (limit, offset) => {
   };
   
   export const getArtists = async (ids) => {
-    const token = await getAccessToken();
+    const token = await getOrGenerateNewAccessToken();
     if (!token) {
       throw new Error('Access token not found.');
     }

--- a/src/services/spotifyAuth.js
+++ b/src/services/spotifyAuth.js
@@ -25,9 +25,18 @@ export const getAccessToken = async () => {
     return newAccessToken;
   }
 
-  await setAuthUrl();
   return null;
 };
+
+export const getOrGenerateNewAccessToken = async () => {
+  const accessToken = await getAccessToken();
+
+  if (!accessToken) {
+    await setAuthUrl();
+  }
+
+  return accessToken;
+}
 
 export const setAuthUrl = async () => {
   logMessage(`Redirecting to authorization URL...`);

--- a/src/utilities/navigationHelpers.js
+++ b/src/utilities/navigationHelpers.js
@@ -1,5 +1,6 @@
 import { useNavigate, useLocation } from "react-router-dom";
 import { logMessage } from './loggingConfig';
+import { getAccessToken } from '../services/spotifyAuth';
 
 export const useNavigationHelpers = () => {
   const navigate = useNavigate();
@@ -11,7 +12,19 @@ export const useNavigationHelpers = () => {
       navigate(path, { replace: true });
     }
   }
+
   const goBack = () => navigate(-1);
 
-  return { goTo, goBack };
+  const checkAuthAndNavigate = async () => {
+    const accessToken = await getAccessToken();
+    if (accessToken) {
+      logMessage('User is authenticated. Redirecting to /genre-album-map.');
+      navigate('/genre-album-map', { replace: true });
+    } else {
+      logMessage('User is not authenticated. Redirecting to /authenticate.');
+      navigate('/authenticate', { replace: true });
+    }
+  };
+
+  return { goTo, goBack, checkAuthAndNavigate };
 };


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* No way for users to read about the app when first visiting
* Login container only contained Login to Spotify button, no info or header at all

## Solution 💡

* Set up header to display when route is `/authenticate` (login container is shown)
* Add an AboutContainer and add this to the overlayMenu
* LoginContainer also contains Info button
* Add a couple of simple tests to verify navigation to about page

### Also included in this PR:

* Updated fonts to comply with Spotify guidelines
* Added a guard clause in loginContainer to prevent navigating to `/authenticate` if authenticated
* Simplified home button navigation by checking if the user is authenticated and conditionally navigating to `/authenticate` or `/genre-album-map`

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written
- [x] The full test suite is passing
- [x] There are no TODOs in the code without a very good reason
