### PR TITLE
34 improve the way genre album maps are shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Environment URLs
 
-[Spotify Genre Browser (main)](https://main.dgutam4ouh3e7.amplifyapp.com/)
+[Genre Browser for Spotify (main)](https://main.dgutam4ouh3e7.amplifyapp.com/)
 
-[Spotify Genre Browser (staging)](https://staging.dgutam4ouh3e7.amplifyapp.com/)
+[Genre Browser for Spotify (staging)](https://staging.dgutam4ouh3e7.amplifyapp.com/)
 
 
 ## Cypress Testing

--- a/cypress/e2e/genreCardBehaviour.cy.js
+++ b/cypress/e2e/genreCardBehaviour.cy.js
@@ -3,23 +3,70 @@ describe('GIVEN I am on the genre grid page', () => {
         cy.mockAPIResponsesAndInitialiseAuthenticatedState();
     });
 
-    it('WHEN I click a genre card \
-             THEN it should expand \
-             WHEN I click it again \
-             THEN it should collapse', () => {
-        cy.get('.genre-grid .genre-section').eq(0).click();
-        cy.get('.genre-grid .genre-section').eq(0).should('have.class', 'expanded');
-        cy.get('.genre-grid .genre-section').eq(1).should('have.class', 'collapsed');
+    describe('WHEN I click on a genre card', () => {
+        beforeEach(() => {
+            cy.get('.genre-section').eq(0).click();
+        });
 
+        it('THEN the relevant genre page is opened', () => {
+            cy.get('.big-genre-title').should('contain.text', "slowcore, spoken word")
+        });
 
-        cy.get('.genre-grid .genre-section').eq(0).click();
-        cy.get('.genre-grid .genre-section').eq(0).should('have.class', 'collapsed');
-    });
+        it('THEN the sort option is A-Z (Artist)', () => {
+            cy.get('.album-item').eq(0).get('.album-name').should('contain.text', 'Test Album One')
+        });
+        
+        describe('WHEN I change the sort option', () => {
+            beforeEach(() => {
+                cy.get('.sort-dropdown').select('alphabetical-desc-artist');
+            })
+            
+            it('THEN the order of the albums changes', () => {
+                cy.get('.album-item').eq(0).get('.album-name').should('contain.text', 'Test Album Three');
+            });
+        });
+        
+        describe('WHEN I change the search query', () => {
+            beforeEach(() => {
+                cy.get('.search-bar').type('Three');
+            });
+            
+            it('THEN the albums are filtered', () => {
+                cy.get('.album-item').eq(0).get('.album-name').should('contain.text', 'Test Album Three');
+                cy.get('.album-item').should('have.length', 1);
+            });
+        });
+        
+        describe('WHEN I click the home button', () => {
+            beforeEach(() => {
+                cy.get('.home-button').click();
+            })
 
-    it('AND the album title and URL are correct', () => {
-        cy.get('.genre-grid .genre-section').eq(0).click();
-        cy.get('.album-name').eq(0).should('contain.text', 'As Days Get Dark');
-        cy.get('.album-link')
-            .should('have.attr', 'href', 'https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J');
+            it('THEN I go back to the genre grid page', () => {
+                cy.get('.page-title').should('contain', 'Your album library');
+                cy.get('.refresh-button').should('exist');
+                cy.get('.genre-grid').should('exist');
+            });
+
+            it('THEN the sort option is Size (Desc)', () => {
+                cy.get('.genre-section').eq(0).should('contain', 'slowcore, spoken word')
+            });
+        });
+
+        describe('WHEN I click the genre title', () => {
+            beforeEach(() => {
+                cy.get('.big-genre-title').click();
+            })
+
+            it('THEN I go back to the genre grid page', () => {
+                cy.get('.page-title').should('contain', 'Your album library');
+                cy.get('.refresh-button').should('exist');
+                cy.get('.genre-grid').should('exist');
+            });
+
+            it('THEN the sort option is Size (Desc)', () => {
+                cy.get('.genre-section').eq(0).should('contain', 'slowcore, spoken word')
+            });
+        });
     });
 });

--- a/cypress/e2e/refreshButton.cy.js
+++ b/cypress/e2e/refreshButton.cy.js
@@ -13,7 +13,7 @@ describe('GIVEN I am on the genre grid page', () => {
     });
 
     it('THEN there should only be one album', () => {
-        cy.get('.genre-grid').children().its('length').should('eq', 1);
+        cy.get('.genre-section').should('have.length', 1);
     });
     
     describe('WHEN I click the refresh button', () => {
@@ -25,11 +25,11 @@ describe('GIVEN I am on the genre grid page', () => {
         });
         
         it('THEN the genre grid should update', () => {
-            cy.get('.genre-grid').children().its('length').should('eq', 2);
+            cy.get('.genre-section').should('have.length', 2);
             cy.get('.genre-grid .genre-section').eq(1).click();
-            cy.get('.album-name').eq(0).should('contain.text', 'The Bends');
+            cy.get('.album-name').eq(0).should('contain.text', 'Test Album Two');
             cy.get('.album-link')
-                .should('have.attr', 'href', 'https://open.spotify.com/album/35UJLpClj5EDrhpNIi4DFg');
+                .should('have.attr', 'href', 'https://open.spotify.com/album/test-album-2');
         });
     });
 });

--- a/cypress/e2e/searchAndSortGenreGrid.cy.js
+++ b/cypress/e2e/searchAndSortGenreGrid.cy.js
@@ -17,13 +17,13 @@ describe('GIVEN I am on the genre grid page', () => {
 
         });
 
-        it('THEN the genre grid should be filtered', () => {
-            cy.get('.genre-grid').children().its('length').should('eq', 1);
+        it.only('THEN the genre grid should be filtered', () => {
+            cy.get('.genre-section').should('have.length', 1);
 
             cy.get('.genre-grid .genre-section').eq(0).click();
-            cy.get('.album-name').eq(0).should('contain.text', 'The Bends');
+            cy.get('.album-name').eq(0).should('contain.text', 'Test Album Two');
             cy.get('.album-link')
-                .should('have.attr', 'href', 'https://open.spotify.com/album/35UJLpClj5EDrhpNIi4DFg');
+                .should('have.attr', 'href', 'https://open.spotify.com/album/test-album-2');
         });
     });
 
@@ -34,13 +34,13 @@ describe('GIVEN I am on the genre grid page', () => {
             cy.get(`[placeholder="${searchBoxPlaceholder}"]`).clear().should('have.value', '');
         });
 
-        it('THEN the genre grid should be reset', () => {
-            cy.get('.genre-grid').children().its('length').should('eq', 2);
+        it.only('THEN the genre grid should be reset', () => {
+            cy.get('.genre-section').should('have.length', 2);
 
             cy.get('.genre-grid .genre-section').eq(0).click();
-            cy.get('.album-name').eq(0).should('contain.text', 'As Days Get Dark');
+            cy.get('.album-name').eq(0).should('contain.text', 'Test Album One');
             cy.get('.album-link')
-                .should('have.attr', 'href', 'https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J');
+                .should('have.attr', 'href', 'https://open.spotify.com/album/test-album-1');
         });
     });
 
@@ -54,8 +54,8 @@ describe('GIVEN I am on the genre grid page', () => {
             cy.get('.sort-dropdown').select('alphabetical-asc');
         });
 
-        it('THEN the genre grid should be sorted alphabetically', () => {
-            cy.get('.genre-grid').children().its('length').should('eq', 2);
+        it.only('THEN the genre grid should be sorted alphabetically', () => {
+            cy.get('.genre-section').should('have.length', 2);
 
             cy.get('.genre-grid .genre-section').first()
                 .find('.genre-title')
@@ -68,8 +68,8 @@ describe('GIVEN I am on the genre grid page', () => {
             cy.get('.sort-dropdown').select('alphabetical-desc');
         });
 
-        it('THEN the genre grid should be sorted reverse alphabetically', () => {
-            cy.get('.genre-grid').children().its('length').should('eq', 2);
+        it.only('THEN the genre grid should be sorted reverse alphabetically', () => {
+            cy.get('.genre-section').should('have.length', 2);
 
             cy.get('.genre-grid .genre-section').first()
                 .find('.genre-title')

--- a/cypress/e2e/searchAndSortGenreGrid.cy.js
+++ b/cypress/e2e/searchAndSortGenreGrid.cy.js
@@ -17,7 +17,7 @@ describe('GIVEN I am on the genre grid page', () => {
 
         });
 
-        it.only('THEN the genre grid should be filtered', () => {
+        it('THEN the genre grid should be filtered', () => {
             cy.get('.genre-section').should('have.length', 1);
 
             cy.get('.genre-grid .genre-section').eq(0).click();
@@ -34,7 +34,7 @@ describe('GIVEN I am on the genre grid page', () => {
             cy.get(`[placeholder="${searchBoxPlaceholder}"]`).clear().should('have.value', '');
         });
 
-        it.only('THEN the genre grid should be reset', () => {
+        it('THEN the genre grid should be reset', () => {
             cy.get('.genre-section').should('have.length', 2);
 
             cy.get('.genre-grid .genre-section').eq(0).click();
@@ -54,7 +54,7 @@ describe('GIVEN I am on the genre grid page', () => {
             cy.get('.sort-dropdown').select('alphabetical-asc');
         });
 
-        it.only('THEN the genre grid should be sorted alphabetically', () => {
+        it('THEN the genre grid should be sorted alphabetically', () => {
             cy.get('.genre-section').should('have.length', 2);
 
             cy.get('.genre-grid .genre-section').first()
@@ -68,7 +68,7 @@ describe('GIVEN I am on the genre grid page', () => {
             cy.get('.sort-dropdown').select('alphabetical-desc');
         });
 
-        it.only('THEN the genre grid should be sorted reverse alphabetically', () => {
+        it('THEN the genre grid should be sorted reverse alphabetically', () => {
             cy.get('.genre-section').should('have.length', 2);
 
             cy.get('.genre-grid .genre-section').first()

--- a/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
+++ b/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
@@ -37,10 +37,10 @@ describe('GIVEN I authenticate successfully', () => {
         cy.get('.genre-grid').should('exist');
     });
     
-    it('AND the album data should load', () => {
+    it.only('AND the album data should load', () => {
         cy.get('.genre-grid .genre-section .genre-title').should('contain', 'slowcore, spoken word');
         cy.get('.genre-grid .genre-section .album-preview img').should('have.attr', 'src')
-        .should('include', 'https://i.scdn.co/image/ab67616d0000b273c9ac1ea80b4c74c09733bcd3');
+        .should('include', 'https://i.scdn.co/image/test-album-1');
     });
 });
 

--- a/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
+++ b/cypress/e2e/spotifyGenreAlbumDataMapping.cy.js
@@ -37,7 +37,7 @@ describe('GIVEN I authenticate successfully', () => {
         cy.get('.genre-grid').should('exist');
     });
     
-    it.only('AND the album data should load', () => {
+    it('AND the album data should load', () => {
         cy.get('.genre-grid .genre-section .genre-title').should('contain', 'slowcore, spoken word');
         cy.get('.genre-grid .genre-section .album-preview img').should('have.attr', 'src')
         .should('include', 'https://i.scdn.co/image/test-album-1');

--- a/cypress/fixtures/mockGetArtistsResponse.json
+++ b/cypress/fixtures/mockGetArtistsResponse.json
@@ -5,14 +5,21 @@
         "slowcore",
         "spoken word"
       ],
-      "id": "6g8Jqb5JMfv92eB2r0awTN"
+      "id": "test-artist-1"
     },
     {
       "genres": [
         "art rock",
         "alternative rock"
       ],
-      "id": "4Z8W4fKeB5YxbusRsdQVPb"
+      "id": "test-artist-2"
+    },
+    {
+      "genres": [
+        "slowcore",
+        "spoken word"
+      ],
+      "id": "test-artist-3"
     }
   ]
 }

--- a/cypress/fixtures/mockGetMySavedAlbumsResponse.json
+++ b/cypress/fixtures/mockGetMySavedAlbumsResponse.json
@@ -3,19 +3,19 @@
     {
       "album": {
         "external_urls": {
-          "spotify": "https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J"
+          "spotify": "https://open.spotify.com/album/test-album-1"
         },
-        "id": "5jMbGYYNDo0lTyUnKtcm8J",
+        "id": "test-album-1",
         "images": [
           {
-            "url": "https://i.scdn.co/image/ab67616d0000b273c9ac1ea80b4c74c09733bcd3"
+            "url": "https://i.scdn.co/image/test-album-1"
           }
         ],
-        "name": "As Days Get Dark",
+        "name": "Test Album One",
         "artists": [
           {
-            "id": "6g8Jqb5JMfv92eB2r0awTN",
-            "name": "Arab Strap"
+            "id": "test-artist-1",
+            "name": "Test Artist One"
           }
         ]
       }
@@ -23,23 +23,43 @@
     {
       "album": {
         "external_urls": {
-          "spotify": "https://open.spotify.com/album/35UJLpClj5EDrhpNIi4DFg"
+          "spotify": "https://open.spotify.com/album/test-album-2"
         },
-        "id": "35UJLpClj5EDrhpNIi4DFg",
+        "id": "test-album-2",
         "images": [
           {
-            "url": "https://i.scdn.co/image/ab67616d0000b2739293c743fa542094336c5e12"
+            "url": "https://i.scdn.co/image/test-album-2"
           }
         ],
-        "name": "The Bends",
+        "name": "Test Album Two",
         "artists": [
           {
-            "id": "4Z8W4fKeB5YxbusRsdQVPb",
-            "name": "Radiohead"
+            "id": "test-artist-2",
+            "name": "Test Artist Two"
+          }
+        ]
+      }
+    },
+    {
+      "album": {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/album/test-album-3"
+        },
+        "id": "test-album-3",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/test-album-3"
+          }
+        ],
+        "name": "Test Album Three",
+        "artists": [
+          {
+            "id": "test-artist-3",
+            "name": "Test Artist Three"
           }
         ]
       }
     }
   ],
-  "total": 2
+  "total": 3
 }

--- a/cypress/fixtures/mockGetMySavedAlbumsResponse_oneAlbum.json
+++ b/cypress/fixtures/mockGetMySavedAlbumsResponse_oneAlbum.json
@@ -3,19 +3,19 @@
     {
       "album": {
         "external_urls": {
-          "spotify": "https://open.spotify.com/album/5jMbGYYNDo0lTyUnKtcm8J"
+          "spotify": "https://open.spotify.com/album/test-album-1"
         },
-        "id": "5jMbGYYNDo0lTyUnKtcm8J",
+        "id": "test-album-1",
         "images": [
           {
-            "url": "https://i.scdn.co/image/ab67616d0000b273c9ac1ea80b4c74c09733bcd3"
+            "url": "https://i.scdn.co/image/test-album-1"
           }
         ],
-        "name": "As Days Get Dark",
+        "name": "Test Album One",
         "artists": [
           {
-            "id": "6g8Jqb5JMfv92eB2r0awTN",
-            "name": "Arab Strap"
+            "id": "test-artist-two",
+            "name": "Test Artist Two"
           }
         ]
       }

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Spotify Genre Browser</title>
+    <title>Genre Browser for Spotify</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Spotify Genre Browser",
-  "name": "Spotify Genre Browser",
+  "short_name": "Genre Browser for Spotify",
+  "name": "Genre Browser for Spotify",
   "icons": [
         {
       "src": "spotify-favicon.png",

--- a/src/App.css
+++ b/src/App.css
@@ -40,7 +40,7 @@ body {
   width: 100%;
   max-width: 600px;
   align-self: center;
-  margin: 10px auto 20px auto; 
+  margin: 10px auto 10px auto; 
 }
 
 .title-container {
@@ -62,65 +62,10 @@ body {
 }
 
 .page-title {
-  /* flex-grow: 1; */
   font-size: 24px;
   font-weight: bold;
   margin: 10px 0;
   text-align: left;
-}
-
-.search-sort-container {
-  /* width: 100%; */
-  display: flex;
-  justify-content: space-between;
-  /* align-items: center; */
-  gap: 10px; /* Space between search bar, dropdown, and refresh button */
-  margin-bottom: 5px;
-}
-
-.search-bar {
-  width: 85%;
-  max-width: 400px;
-  padding: 10px;
-  /* margin: 20px auto; */
-  border: none;
-  border-radius: 50px;
-  background-color: #282828;
-  color: #ffffff;
-  font-size: 16px;
-  outline: none;
-  transition: background-color 0.3s ease;
-}
-
-.search-bar::placeholder {
-  color: #b3b3b3;
-}
-
-.search-bar:focus {
-  background-color: #3e3e3e;
-}
-
-.sort-dropdown {
-  padding: 10px;
-  border: none;
-  border-radius: 10px;
-  background-color: #282828;
-  color: #ffffff;
-  font-size: 16px;
-  outline: none;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  transition: background-color 0.3s ease;
-}
-
-.sort-dropdown:focus {
-  background-color: #3e3e3e;
-}
-
-.sort-dropdown option {
-  background-color: #121212;
-  color: #ffffff;
 }
 
 .albums-container {
@@ -133,8 +78,4 @@ body {
 .no-albums {
   font-size: 20px;
   color: #b3b3b3;
-}
-
-@media (max-width: 768px) {
-  
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Circular', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Helvetica Neue';
   background-color: #121212;
   color: #ffffff;
 }
@@ -10,12 +10,11 @@ body {
   padding: 0 20px;
 }
 
-/* Container for centering the login button */
 .login-container {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 40vh; /* Full height to center vertically */
+  height: 40vh; 
 }
 
 /* Login Button Styles */

--- a/src/App.js
+++ b/src/App.js
@@ -22,8 +22,6 @@ Amplify.configure(awsconfig);
 
 function App() {
   const { showBoundary } = useErrorBoundary()
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortOption, setSortOption] = useState('number-desc');
   const genreGridRef = useRef();
   const { isModalOpen, modalParams, openModal, closeModal } = useModal();
   const { goTo } = useNavigationHelpers();
@@ -52,14 +50,6 @@ function App() {
       }
     }
   }
-
-  const handleSearch = (event) => {
-    setSearchQuery(event.target.value.toLowerCase());
-  };
-
-  const handleSortChange = (event) => {
-    setSortOption(event.target.value);
-  };
 
   const handleDisconnect = async () => {
     logMessage('Disconnecting Spotify account...');
@@ -101,8 +91,6 @@ function App() {
       <ErrorBoundary FallbackComponent={ErrorFallback} onError={handleError}>
         <HeaderContainer
           onRefresh={handleGenreAlbumMapRefresh}
-          onSearch={handleSearch}
-          onSortChange={handleSortChange}
           onOpenDisconnectModal={handleOpenDisconnectModal}
           toggleMenu={toggleMenu}
         />
@@ -112,8 +100,8 @@ function App() {
         <Routes>
           <Route path="*" element={<LoginContainer />} />
           <Route path="/authenticate" element={<LoginContainer />} />
-          <Route path="/genre-album-map" element={<GenreGridContainer searchQuery={searchQuery} sortOption={sortOption} ref={genreGridRef} />} />
-          <Route path="/genre" element={<GenreGridContainer searchQuery={searchQuery} sortOption={sortOption} ref={genreGridRef} />} />
+          <Route path="/genre-album-map" element={<GenreGridContainer ref={genreGridRef} />} />
+          <Route path="/genre" element={<GenreGridContainer ref={genreGridRef} />} />
           <Route path="/privacy-policy" element={<PrivacyPolicyContainer />} />
           <Route path="/about" element={<AboutContainer />} />
         </Routes>

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,6 @@ import useModal from './hooks/useModal';
 import { Route, Routes } from "react-router-dom";
 import { useNavigationHelpers } from './utilities/navigationHelpers';
 import OverlayMenu from './containers/overlayMenu/overlayMenu';
-import GenreContainer from './containers/genreContainer/genreContainer';
 
 Amplify.configure(awsconfig);
 
@@ -97,15 +96,6 @@ function App() {
     });
   };
 
-  function getGenreContainerProps(genreGridRef) {
-    const genreParam = new URLSearchParams(window.location.search).get('g');
-    const groupedAlbums = genreGridRef.current?.getGroupedAlbums() || {};
-    return {
-      genre: genreParam || '[Unknown Genre]',
-      albums: groupedAlbums[genreParam] || []
-    };
-  }
-
   return (
     <div className="App">
       <ErrorBoundary FallbackComponent={ErrorFallback} onError={handleError}>
@@ -123,10 +113,7 @@ function App() {
           <Route path="*" element={<LoginContainer />} />
           <Route path="/authenticate" element={<LoginContainer />} />
           <Route path="/genre-album-map" element={<GenreGridContainer searchQuery={searchQuery} sortOption={sortOption} ref={genreGridRef} />} />
-          <Route 
-            path="/genre" 
-            element={<GenreContainer {...getGenreContainerProps(genreGridRef)} />} 
-          />
+          <Route path="/genre" element={<GenreGridContainer searchQuery={searchQuery} sortOption={sortOption} ref={genreGridRef} />} />
           <Route path="/privacy-policy" element={<PrivacyPolicyContainer />} />
           <Route path="/about" element={<AboutContainer />} />
         </Routes>

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import useModal from './hooks/useModal';
 import { Route, Routes } from "react-router-dom";
 import { useNavigationHelpers } from './utilities/navigationHelpers';
 import OverlayMenu from './containers/overlayMenu/overlayMenu';
+import GenreContainer from './containers/genreContainer/genreContainer';
 
 Amplify.configure(awsconfig);
 
@@ -96,6 +97,15 @@ function App() {
     });
   };
 
+  function getGenreContainerProps(genreGridRef) {
+    const genreParam = new URLSearchParams(window.location.search).get('g');
+    const groupedAlbums = genreGridRef.current?.getGroupedAlbums() || {};
+    return {
+      genre: genreParam || '[Unknown Genre]',
+      albums: groupedAlbums[genreParam] || []
+    };
+  }
+
   return (
     <div className="App">
       <ErrorBoundary FallbackComponent={ErrorFallback} onError={handleError}>
@@ -113,6 +123,10 @@ function App() {
           <Route path="*" element={<LoginContainer />} />
           <Route path="/authenticate" element={<LoginContainer />} />
           <Route path="/genre-album-map" element={<GenreGridContainer searchQuery={searchQuery} sortOption={sortOption} ref={genreGridRef} />} />
+          <Route 
+            path="/genre" 
+            element={<GenreContainer {...getGenreContainerProps(genreGridRef)} />} 
+          />
           <Route path="/privacy-policy" element={<PrivacyPolicyContainer />} />
           <Route path="/about" element={<AboutContainer />} />
         </Routes>

--- a/src/components/SearchSortContainer.css
+++ b/src/components/SearchSortContainer.css
@@ -1,8 +1,6 @@
 .search-sort-container {
-  display: flex;
-  justify-content: space-between;
-  gap: 5px;
-  margin: 0px -5px 15px -5px;
+  align-self: center;
+  margin: 0px auto 15px auto; 
 }
 
 .search-bar {

--- a/src/components/SearchSortContainer.css
+++ b/src/components/SearchSortContainer.css
@@ -1,0 +1,50 @@
+.search-sort-container {
+  display: flex;
+  justify-content: space-between;
+  gap: 5px;
+  margin: 0px -5px 15px -5px;
+}
+
+.search-bar {
+  width: 85%;
+  max-width: 400px;
+  padding: 10px;
+  border: none;
+  border-radius: 50px;
+  background-color: #282828;
+  color: #ffffff;
+  font-size: 16px;
+  outline: none;
+  transition: background-color 0.3s ease;
+}
+
+.search-bar::placeholder {
+  color: #b3b3b3;
+}
+
+.search-bar:focus {
+  background-color: #3e3e3e;
+}
+
+.sort-dropdown {
+  padding: 10px;
+  border: none;
+  border-radius: 10px;
+  background-color: #282828;
+  color: #ffffff;
+  font-size: 16px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  transition: background-color 0.3s ease;
+}
+
+.sort-dropdown:focus {
+  background-color: #3e3e3e;
+}
+
+.sort-dropdown option {
+  background-color: #121212;
+  color: #ffffff;
+}

--- a/src/components/SearchSortContainer.js
+++ b/src/components/SearchSortContainer.js
@@ -2,35 +2,30 @@ import React from "react";
 import "./SearchSortContainer.css";
 
 function SearchSortContainer({
-  searchQuery,
-  setSearchQuery,
-  sortOption,
-  setSortOption,
-  disableSizeOptions,
+  onSearchQueryChange,
+  onSortOptionChange,
   placeholderText,
+  sortOptions,
+  selectedSortOption,
 }) {
   return (
     <div className="search-sort-container">
       <input
         type="text"
         placeholder={placeholderText}
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value.toLowerCase())}
+        onChange={(e) => onSearchQueryChange(e.target.value.toLowerCase())}
         className="search-bar"
       />
       <select
-        value={sortOption}
-        onChange={(e) => setSortOption(e.target.value)}
+        value={selectedSortOption}
+        onChange={(e) => onSortOptionChange(e.target.value)}
         className="sort-dropdown"
       >
-        <option value="alphabetical-asc">(A-Z)</option>
-        <option value="alphabetical-desc">(Z-A)</option>
-        {!disableSizeOptions && (
-          <>
-            <option value="number-asc">Size (Asc)</option>
-            <option value="number-desc">Size (Desc)</option>
-          </>
-        )}
+        {sortOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
       </select>
     </div>
   );

--- a/src/components/SearchSortContainer.js
+++ b/src/components/SearchSortContainer.js
@@ -1,0 +1,39 @@
+import React from "react";
+import "./SearchSortContainer.css";
+
+function SearchSortContainer({
+  searchQuery,
+  setSearchQuery,
+  sortOption,
+  setSortOption,
+  disableSizeOptions,
+  placeholderText,
+}) {
+  return (
+    <div className="search-sort-container">
+      <input
+        type="text"
+        placeholder={placeholderText}
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value.toLowerCase())}
+        className="search-bar"
+      />
+      <select
+        value={sortOption}
+        onChange={(e) => setSortOption(e.target.value)}
+        className="sort-dropdown"
+      >
+        <option value="alphabetical-asc">(A-Z)</option>
+        <option value="alphabetical-desc">(Z-A)</option>
+        {!disableSizeOptions && (
+          <>
+            <option value="number-asc">Size (Asc)</option>
+            <option value="number-desc">Size (Desc)</option>
+          </>
+        )}
+      </select>
+    </div>
+  );
+}
+
+export default SearchSortContainer;

--- a/src/containers/aboutContainer/aboutContainer.js
+++ b/src/containers/aboutContainer/aboutContainer.js
@@ -1,9 +1,9 @@
 const AboutContainer = () => {
     return (
         <div className="about-container">
-            <h1>About Spotify Genre Browser</h1>
+            <h1>About Genre Browser for Spotify</h1>
             <p>
-                Spotify Genre Browser is a web application that helps you explore your saved albums on Spotify by grouping them into genres. 
+                Genre Browser for Spotify is a web application that helps you explore your saved albums on Spotify by grouping them into genres. 
                 It provides an intuitive interface to navigate through your music library and discover patterns in your listening habits.
             </p>
             <h2>Features</h2>

--- a/src/containers/genreContainer/genreContainer.css
+++ b/src/containers/genreContainer/genreContainer.css
@@ -1,0 +1,86 @@
+.genre-container {
+  color: #ffffff;
+}
+
+.big-genre-title {
+  font-size: 24px;
+  font-weight: bold;
+  margin: 0px;
+  text-align: center;
+}
+
+.album-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 15px;
+  justify-content: center;
+}
+
+.album-item {
+  width: 100px;
+  height: auto;
+  font-size: 18px;
+  color: #b3b3b3;
+  border: 1px solid #333;
+  border-radius: 10px;
+  background-color: #181818;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease;
+  padding: 6px;
+}
+
+.album-item:hover {
+  transform: scale(1.05);
+}
+
+.album-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+  height: 100%;
+}
+
+.album-image {
+  width: 100px;
+  height: 100px;
+  border-radius: 2px;
+  margin-bottom: 5px;
+}
+
+.album-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 300;
+  height: 100%;
+}
+
+.album-artist {
+  display: flex;
+}
+
+.album-name {
+  font-style: italic;
+  color: #1db954;
+}
+
+.album-artist, .album-name {
+  max-height: 2.6em; 
+  line-height: 1.2em; 
+  font-size: 15px;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}

--- a/src/containers/genreContainer/genreContainer.js
+++ b/src/containers/genreContainer/genreContainer.js
@@ -1,41 +1,74 @@
-import React from 'react';
-import './genreContainer.css';
+import React, { useState } from "react";
+import SearchSortContainer from "../../components/SearchSortContainer";
+import "./genreContainer.css";
 
-function GenreContainer({ genre, albums, onBack, searchQuery, sortOption }) {
-  const filteredAlbums = albums.filter(
-    (album) =>
-      album.name.toLowerCase().includes(searchQuery) ||
-      album.artists.some((artist) => artist.name.toLowerCase().includes(searchQuery))
-  );
+function GenreContainer({ genre, albums, onBack }) {
+    const [searchQuery, setSearchQuery] = useState("");
+    const [sortOption, setSortOption] = useState("alphabetical-asc-artist");
 
-  const sortedAlbums = filteredAlbums.sort((a, b) => {
-    if (sortOption === 'alphabetical-asc') {
-      return a.name.localeCompare(b.name);
-    } else if (sortOption === 'alphabetical-desc') {
-      return b.name.localeCompare(a.name);
-    }
-    return 0; 
-  });
+    const sortOptions = [
+        { value: "alphabetical-asc-album", label: "A-Z (Album)" },
+        { value: "alphabetical-desc-album", label: "Z-A (Album)" },
+        { value: "alphabetical-asc-artist", label: "A-Z (Artist)" },
+        { value: "alphabetical-desc-artist", label: "Z-A (Artist)" },
+    ];
 
-  return (
-    <div className="genre-container">
-      <h1 className="big-genre-title" onClick={onBack}>{genre}</h1>
-      <hr className="horizontal-line" onClick={onBack} />
-      <div className="album-grid">
-        {sortedAlbums.map((album) => (
-          <div key={album.id} className="album-item">
-            <a href={album.external_urls.spotify} target="_blank" rel="noopener noreferrer" className="album-link">
-              <img src={album.images[0].url} alt={album.name} className="album-image" />
-              <div className="album-info">
-                <span className="album-name">{album.name}</span>
-                <span className="album-artist">{album.artists[0].name}</span>
-              </div>
-            </a>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+    const filteredAlbums = albums.filter(
+        (album) =>
+            album.name.toLowerCase().includes(searchQuery) ||
+            album.artists.some((artist) =>
+                artist.name.toLowerCase().includes(searchQuery)
+            )
+    );
+
+    const sortedAlbums = filteredAlbums.sort((a, b) => {
+        if (sortOption === "alphabetical-asc-album") {
+            return a.name.localeCompare(b.name);
+        } else if (sortOption === "alphabetical-desc-album") {
+            return b.name.localeCompare(a.name);
+        } else if (sortOption === "alphabetical-asc-artist") {
+            return a.artists[0].name.localeCompare(b.artists[0].name);
+        } else if (sortOption === "alphabetical-desc-artist") {
+            return b.artists[0].name.localeCompare(a.artists[0].name);
+        }
+        return 0;
+    });
+
+    return (
+        <div>
+            <SearchSortContainer
+                onSearchQueryChange={setSearchQuery}
+                onSortOptionChange={setSortOption}
+                selectedSortOption={sortOption}
+                placeholderText="Search albums or artists..."
+                sortOptions={sortOptions}
+            />
+            <h1 className="big-genre-title" onClick={onBack}>{genre}</h1>
+            <hr className="horizontal-line" onClick={onBack} />
+            <div className="album-grid">
+                {sortedAlbums.map((album) => (
+                    <div key={album.id} className="album-item">
+                        <a
+                            href={album.external_urls.spotify}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="album-link"
+                        >
+                            <img
+                                src={album.images[0].url}
+                                alt={album.name}
+                                className="album-image"
+                            />
+                            <div className="album-info">
+                                <span className="album-name">{album.name}</span>
+                                <span className="album-artist">{album.artists[0].name}</span>
+                            </div>
+                        </a>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
 }
 
 export default GenreContainer;

--- a/src/containers/genreContainer/genreContainer.js
+++ b/src/containers/genreContainer/genreContainer.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import './genreContainer.css';
+
+function GenreContainer({ genre, albums }) {
+    return (
+        <div className="genre-container">
+            <h1 className="big-genre-title">{genre}</h1>
+            <hr className="horizontal-line" />
+            <div className="album-grid">
+                {albums.map((album) => (
+                    <div key={album.id} className="album-item">
+                        <a href={album.external_urls.spotify} target="_blank" rel="noopener noreferrer" className="album-link">
+                            <img src={album.images[0].url} alt={album.name} className="album-image" />
+                            <div className="album-info">
+                                <span className="album-name">{album.name}</span>
+                                <span className="album-artist">{album.artists[0].name}</span>
+                            </div>
+                        </a>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default GenreContainer;

--- a/src/containers/genreContainer/genreContainer.js
+++ b/src/containers/genreContainer/genreContainer.js
@@ -1,26 +1,41 @@
 import React from 'react';
 import './genreContainer.css';
 
-function GenreContainer({ genre, albums, onBack }) {
-    return (
-        <div className="genre-container">
-            <h1 className="big-genre-title" onClick={onBack}>{genre}</h1>
-            <hr className="horizontal-line" onClick={onBack} />
-            <div className="album-grid">
-                {albums.map((album) => (
-                    <div key={album.id} className="album-item">
-                        <a href={album.external_urls.spotify} target="_blank" rel="noopener noreferrer" className="album-link">
-                            <img src={album.images[0].url} alt={album.name} className="album-image" />
-                            <div className="album-info">
-                                <span className="album-name">{album.name}</span>
-                                <span className="album-artist">{album.artists[0].name}</span>
-                            </div>
-                        </a>
-                    </div>
-                ))}
-            </div>
-        </div>
-    );
+function GenreContainer({ genre, albums, onBack, searchQuery, sortOption }) {
+  const filteredAlbums = albums.filter(
+    (album) =>
+      album.name.toLowerCase().includes(searchQuery) ||
+      album.artists.some((artist) => artist.name.toLowerCase().includes(searchQuery))
+  );
+
+  const sortedAlbums = filteredAlbums.sort((a, b) => {
+    if (sortOption === 'alphabetical-asc') {
+      return a.name.localeCompare(b.name);
+    } else if (sortOption === 'alphabetical-desc') {
+      return b.name.localeCompare(a.name);
+    }
+    return 0; 
+  });
+
+  return (
+    <div className="genre-container">
+      <h1 className="big-genre-title" onClick={onBack}>{genre}</h1>
+      <hr className="horizontal-line" onClick={onBack} />
+      <div className="album-grid">
+        {sortedAlbums.map((album) => (
+          <div key={album.id} className="album-item">
+            <a href={album.external_urls.spotify} target="_blank" rel="noopener noreferrer" className="album-link">
+              <img src={album.images[0].url} alt={album.name} className="album-image" />
+              <div className="album-info">
+                <span className="album-name">{album.name}</span>
+                <span className="album-artist">{album.artists[0].name}</span>
+              </div>
+            </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default GenreContainer;

--- a/src/containers/genreContainer/genreContainer.js
+++ b/src/containers/genreContainer/genreContainer.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import './genreContainer.css';
 
-function GenreContainer({ genre, albums }) {
+function GenreContainer({ genre, albums, onBack }) {
     return (
         <div className="genre-container">
-            <h1 className="big-genre-title">{genre}</h1>
-            <hr className="horizontal-line" />
+            <h1 className="big-genre-title" onClick={onBack}>{genre}</h1>
+            <hr className="horizontal-line" onClick={onBack} />
             <div className="album-grid">
                 {albums.map((album) => (
                     <div key={album.id} className="album-item">

--- a/src/containers/genreGridContainer/genreGridContainer.css
+++ b/src/containers/genreGridContainer/genreGridContainer.css
@@ -134,3 +134,54 @@
   justify-content: center;
   text-align: center;
 }
+
+.search-sort-container {
+  display: flex;
+  justify-content: space-between;
+  gap: 5px;
+  margin: 0px -5px 15px -5px;
+}
+
+.search-bar {
+  width: 85%;
+  max-width: 400px;
+  padding: 10px;
+  border: none;
+  border-radius: 50px;
+  background-color: #282828;
+  color: #ffffff;
+  font-size: 16px;
+  outline: none;
+  transition: background-color 0.3s ease;
+}
+
+.search-bar::placeholder {
+  color: #b3b3b3;
+}
+
+.search-bar:focus {
+  background-color: #3e3e3e;
+}
+
+.sort-dropdown {
+  padding: 10px;
+  border: none;
+  border-radius: 10px;
+  background-color: #282828;
+  color: #ffffff;
+  font-size: 16px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  transition: background-color 0.3s ease;
+}
+
+.sort-dropdown:focus {
+  background-color: #3e3e3e;
+}
+
+.sort-dropdown option {
+  background-color: #121212;
+  color: #ffffff;
+}

--- a/src/containers/genreGridContainer/genreGridContainer.css
+++ b/src/containers/genreGridContainer/genreGridContainer.css
@@ -136,10 +136,13 @@
 }
 
 .search-sort-container {
+  width: 100%;
+  max-width: 650px;
+  align-self: center;
   display: flex;
   justify-content: space-between;
   gap: 5px;
-  margin: 0px -5px 15px -5px;
+  margin: 0 auto 15px auto; 
 }
 
 .search-bar {

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -7,6 +7,7 @@ import logMessage from "../../utilities/loggingConfig";
 import './genreGridContainer.css';
 import GenreContainer from '../genreContainer/genreContainer';
 import { useNavigate } from "react-router-dom";
+import SearchSortContainer from '../../components/SearchSortContainer';
 
 const GenreGridContainer = forwardRef((props, genreGridRef) => {
   const [groupedAlbums, setGroupedAlbums] = useState({});
@@ -31,7 +32,7 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
     const initializeData = async () => {
       try {
         if (Object.keys(groupedAlbums).length > 0) {
-          logMessage(`Using cached genre album map: ${JSON.stringify(groupedAlbums)}`);
+          logMessage(`Using cached genre album map`);
           return;
         }
         const cachedGenreAlbumMap = await getCachedEntry('data', 'grouped_albums');
@@ -227,6 +228,7 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
   }
 
   const handleGenreClick = (genre, albums) => {
+    setSortOption('alphabetical-asc');
     setSelectedGenre({ genre, albums });
     navigate(`/genre?g=${encodeURIComponent(genre)}`);
   };
@@ -238,6 +240,18 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
 
   return (
     <div>
+      <SearchSortContainer
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        sortOption={sortOption}
+        setSortOption={setSortOption}
+        disableSizeOptions={selectedGenre !== null}
+        placeholderText={
+          selectedGenre
+            ? "Search albums and artists..."
+            : "Search genres, albums, and artists..."
+        }
+      />
       {loadingMessage ? (
         <p className="loading-message">{loadingMessage}</p>
       ) : selectedGenre ? (
@@ -245,35 +259,21 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
           genre={selectedGenre.genre}
           albums={selectedGenre.albums}
           onBack={handleBackToGrid}
+          searchQuery={searchQuery}
+          sortOption={sortOption}
         />
       ) : (
-        <>
-          <div className="search-sort-container">
-            <input
-              type="text"
-              placeholder="Search genres, albums, and artists..."
-              onChange={handleSearch}
-              className="search-bar"
+        <div className="genre-grid">
+          {sortedGenres.map(([genre, albums], index) => (
+            <GenreCard
+              key={genre}
+              genre={genre}
+              albums={albums}
+              index={index}
+              onClick={() => handleGenreClick(genre, albums)}
             />
-            <select onChange={handleSortChange} className="sort-dropdown" defaultValue="number-desc">
-              <option value="alphabetical-asc">(A-Z)</option>
-              <option value="alphabetical-desc">(Z-A)</option>
-              <option value="number-asc">Size (Asc)</option>
-              <option value="number-desc">Size (Desc)</option>
-            </select>
-          </div>
-          <div className="genre-grid">
-            {sortedGenres.map(([genre, albums], index) => (
-              <GenreCard
-                key={genre}
-                genre={genre}
-                albums={albums}
-                index={index}
-                onClick={() => handleGenreClick(genre, albums)}
-              />
-            ))}
-          </div>
-        </>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -38,7 +38,7 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
           return;
         }
         const cachedGenreAlbumMap = await getCachedEntry('data', 'grouped_albums');
-        if (cachedGenreAlbumMap) {
+        if (cachedGenreAlbumMap && Object.keys(cachedGenreAlbumMap).length > 0) {
           logMessage('Using cached genre album map.');
           setGroupedAlbums(cachedGenreAlbumMap);
         } else {
@@ -63,7 +63,7 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
       }
 
       const cachedGenreAlbumMap = await getCachedEntry('data', 'grouped_albums');
-      if (cachedGenreAlbumMap) {
+      if (cachedGenreAlbumMap && Object.keys(cachedGenreAlbumMap).length > 0) {
         setGroupedAlbums(cachedGenreAlbumMap);
       } else {
         const allAlbums = await fetchAllSavedAlbums();

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -165,6 +165,7 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
       await delay(delayTimeMs); // Avoid hitting rate limits
     }
 
+    setLoadingMessage('');
     logMessage('Finished grouping albums by artist genre.');
     return genreAlbumMap;
   }, []);

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -162,12 +162,34 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
         });
       });
 
-      await delay(delayTimeMs); // Avoid hitting rate limits
+      await delay(delayTimeMs); 
     }
+
+    // Combine genres with identical albums
+    const combinedGenreAlbumMap = new Map();
+
+    Object.entries(genreAlbumMap).forEach(([genre, albums]) => {
+      const albumIds = albums.map(album => album.id).sort().join(',');
+      if (combinedGenreAlbumMap.has(albumIds)) {
+        combinedGenreAlbumMap.set(
+          albumIds,
+          `${combinedGenreAlbumMap.get(albumIds)}, ${genre}`
+        );
+      } else {
+        combinedGenreAlbumMap.set(albumIds, genre);
+      }
+    });
+
+    const finalGenreAlbumMap = {};
+    combinedGenreAlbumMap.forEach((genres, albumIds) => {
+      finalGenreAlbumMap[genres] = Object.values(genreAlbumMap).find(
+        albums => albums.map(album => album.id).sort().join(',') === albumIds
+      );
+    });
 
     setLoadingMessage('');
     logMessage('Finished grouping albums by artist genre.');
-    return genreAlbumMap;
+    return finalGenreAlbumMap;
   }, []);
 
   // Allow these methods to be called from the parent element

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -25,6 +25,8 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
     const url = new URL(window.location.href);
     if (url.pathname === '/genre-album-map') {
       setSelectedGenre(null);
+      setSortOption('number-desc'); 
+      setSearchQuery(''); 
     }
   }, [navigate]);
 
@@ -235,23 +237,20 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
 
   const handleBackToGrid = () => {
     setSelectedGenre(null);
+    setSortOption('number-desc');
+    setSearchQuery('');
     navigate('/genre-album-map');
   };
 
+  const sortOptions = [
+    { value: "alphabetical-asc", label: "A-Z (Genre)" },
+    { value: "alphabetical-desc", label: "Z-A (Genre)" },
+    { value: "number-asc", label: "Size (Asc)" },
+    { value: "number-desc", label: "Size (Desc)" },
+  ];
+
   return (
     <div>
-      <SearchSortContainer
-        searchQuery={searchQuery}
-        setSearchQuery={setSearchQuery}
-        sortOption={sortOption}
-        setSortOption={setSortOption}
-        disableSizeOptions={selectedGenre !== null}
-        placeholderText={
-          selectedGenre
-            ? "Search albums and artists..."
-            : "Search genres, albums, and artists..."
-        }
-      />
       {loadingMessage ? (
         <p className="loading-message">{loadingMessage}</p>
       ) : selectedGenre ? (
@@ -263,16 +262,29 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
           sortOption={sortOption}
         />
       ) : (
-        <div className="genre-grid">
-          {sortedGenres.map(([genre, albums], index) => (
-            <GenreCard
-              key={genre}
-              genre={genre}
-              albums={albums}
-              index={index}
-              onClick={() => handleGenreClick(genre, albums)}
-            />
-          ))}
+        <div>
+          <SearchSortContainer
+            onSearchQueryChange={setSearchQuery}
+            onSortOptionChange={setSortOption}
+            selectedSortOption={sortOption}
+            placeholderText={
+              selectedGenre
+                ? "Search albums and artists..."
+                : "Search genres, albums, and artists..."
+            }
+            sortOptions={selectedGenre ? sortOptions.slice(0, 2) : sortOptions}
+          />
+          <div className="genre-grid">
+            {sortedGenres.map(([genre, albums], index) => (
+              <GenreCard
+                key={genre}
+                genre={genre}
+                albums={albums}
+                index={index}
+                onClick={() => handleGenreClick(genre, albums)}
+              />
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/src/containers/headerContainer/headerContainer.js
+++ b/src/containers/headerContainer/headerContainer.js
@@ -5,7 +5,7 @@ import { faSyncAlt, faBars, faHouse, faCircleInfo } from '@fortawesome/free-soli
 import { useLocation } from "react-router-dom";
 import { useNavigationHelpers } from '../../utilities/navigationHelpers';
 
-function HeaderContainer({ onRefresh, onSearch, onSortChange, onOpenDisconnectModal, toggleMenu }) {
+function HeaderContainer({ onRefresh, onOpenDisconnectModal, toggleMenu }) {
     const location = useLocation();
     const { goTo, checkAuthAndNavigate } = useNavigationHelpers();
 
@@ -40,20 +40,6 @@ function HeaderContainer({ onRefresh, onSearch, onSortChange, onOpenDisconnectMo
                         <FontAwesomeIcon icon={faSyncAlt} />
                     </button>
                 </div>
-                <div className="search-sort-container">
-                    <input
-                        type="text"
-                        placeholder="Search genres, albums, and artists..."
-                        onChange={onSearch}
-                        className="search-bar"
-                    />
-                    <select onChange={onSortChange} className="sort-dropdown" defaultValue="number-desc">
-                        <option value="alphabetical-asc">(A-Z)</option>
-                        <option value="alphabetical-desc">(Z-A)</option>
-                        <option value="number-asc">Size (Asc)</option>
-                        <option value="number-desc">Size (Desc)</option>
-                    </select>
-                </div>
             </div>
         );
     }
@@ -68,20 +54,6 @@ function HeaderContainer({ onRefresh, onSearch, onSortChange, onOpenDisconnectMo
                     <button className="home-button" onClick={async () => await checkAuthAndNavigate()}>
                         <FontAwesomeIcon icon={faHouse} />
                     </button>
-                </div>
-                <div className="search-sort-container">
-                    <input
-                        type="text"
-                        placeholder="Search albums and artists..."
-                        onChange={onSearch}
-                        className="search-bar"
-                    />
-                    <select onChange={onSortChange} className="sort-dropdown" defaultValue="number-desc">
-                        <option value="alphabetical-asc">(A-Z)</option>
-                        <option value="alphabetical-desc">(Z-A)</option>
-                        <option value="number-asc">Size (Asc)</option>
-                        <option value="number-desc">Size (Desc)</option>
-                    </select>
                 </div>
             </div>
         );

--- a/src/containers/headerContainer/headerContainer.js
+++ b/src/containers/headerContainer/headerContainer.js
@@ -57,6 +57,35 @@ function HeaderContainer({ onRefresh, onSearch, onSortChange, onOpenDisconnectMo
             </div>
         );
     }
+    else if (location.pathname.startsWith('/genre')) {
+        return (
+            <div className="header-container">
+                <div className="title-container">
+                    <button className="menu-button" onClick={toggleMenu}>
+                        <FontAwesomeIcon icon={faBars} />
+                    </button>
+                    <h1 className="page-title">Your album library</h1>
+                    <button className="home-button" onClick={async () => await checkAuthAndNavigate()}>
+                        <FontAwesomeIcon icon={faHouse} />
+                    </button>
+                </div>
+                <div className="search-sort-container">
+                    <input
+                        type="text"
+                        placeholder="Search albums and artists..."
+                        onChange={onSearch}
+                        className="search-bar"
+                    />
+                    <select onChange={onSortChange} className="sort-dropdown" defaultValue="number-desc">
+                        <option value="alphabetical-asc">(A-Z)</option>
+                        <option value="alphabetical-desc">(Z-A)</option>
+                        <option value="number-asc">Size (Asc)</option>
+                        <option value="number-desc">Size (Desc)</option>
+                    </select>
+                </div>
+            </div>
+        );
+    }
     else if (location.pathname === '/about') {
         return (
             <div className="header-container">

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Helvetica Neue';
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* The way the genre cards are opened was ugly
* It also wasn't very extensible
* This change is also required to comply with Spotify's developer guidelines (to be finished in another ticket)

## Solution 💡

* Introduced new genreContainer
* Introduced new SearchSortContainer
* Move all sorting and filtering logic into genreGridContainer and genreContainer
* Some mucking about to make sure navigation all works smoothly
* New tests and updated existing tests

### Also included in this PR

* Rename Spotify Genre Browser to Genre Browser for Spotify
* Adjust tests to use obvious test names (e.g. `Test Album One` instead of real albums, for simplicity)

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written
- [x] The full test suite is passing
- [x] There are no TODOs in the code without a very good reason
