### PR TITLE
65 load in smaller versions of images

### DIFF
--- a/cypress/e2e/unauthenticatedNavigation.cy.js
+++ b/cypress/e2e/unauthenticatedNavigation.cy.js
@@ -52,7 +52,7 @@ describe('GIVEN I am on the donate page', () => {
         cy.visit('/donate');
     });
 
-    it('THEN the about page should be displayed', () => {    
+    it('THEN the donate page should be displayed', () => {    
         cy.get('.page-title').should('contain', 'Donate');
         cy.get('.home-button').should('exist');
         cy.get('.donate-container').should('exist');

--- a/cypress/fixtures/mockGetMySavedAlbumsResponse.json
+++ b/cypress/fixtures/mockGetMySavedAlbumsResponse.json
@@ -8,6 +8,9 @@
         "id": "test-album-1",
         "images": [
           {
+            "url": "https://i.scdn.co/image/dont-use-this-one"
+          },
+          {
             "url": "https://i.scdn.co/image/test-album-1"
           }
         ],
@@ -28,6 +31,9 @@
         "id": "test-album-2",
         "images": [
           {
+            "url": "https://i.scdn.co/image/dont-use-this-one"
+          },
+          {
             "url": "https://i.scdn.co/image/test-album-2"
           }
         ],
@@ -47,6 +53,9 @@
         },
         "id": "test-album-3",
         "images": [
+          {
+            "url": "https://i.scdn.co/image/dont-use-this-one"
+          },
           {
             "url": "https://i.scdn.co/image/test-album-3"
           }

--- a/cypress/fixtures/mockGetMySavedAlbumsResponse_oneAlbum.json
+++ b/cypress/fixtures/mockGetMySavedAlbumsResponse_oneAlbum.json
@@ -8,6 +8,9 @@
         "id": "test-album-1",
         "images": [
           {
+            "url": "https://i.scdn.co/image/dont-use-this-one"
+          },
+          {
             "url": "https://i.scdn.co/image/test-album-1"
           }
         ],

--- a/src/containers/genreContainer/genreContainer.js
+++ b/src/containers/genreContainer/genreContainer.js
@@ -62,7 +62,7 @@ function GenreContainer({ genre, albums, onBack }) {
                             className="album-link"
                         >
                             <img
-                                src={album.images[0].url}
+                                src={album.images[1].url}
                                 alt={album.name}
                                 className="album-image"
                             />

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -134,7 +134,15 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
       }
     } while (response.error && response.error.status === 429);
 
-    return [response.items.map(item => item.album), response.total];
+    const reducedAlbums = response.items.map(item => ({
+      id: item.album.id,
+      name: item.album.name,
+      artists: item.album.artists.map(artist => ({ id: artist.id, name: artist.name })),
+      external_urls: { spotify: item.album.external_urls.spotify },
+      images: [null, { url: item.album.images[1]?.url }],
+    }));
+
+    return [reducedAlbums, response.total];
   }
 
   const groupAlbumsByArtistGenre = useCallback(async (albums) => {

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -321,7 +321,7 @@ function GenreCard({ genre, albums, onClick }) {
         {albums.slice(0, albums.length < 4 ? 1 : 4).map((album, index) => (
           <img
             key={album.id}
-            src={album.images[0].url}
+            src={album.images[1].url}
             alt={album.name}
             className={`album-preview-image ${albums.length < 4 ? 'single-album' : ''}`}
           />


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* Full size images were used for a preview that takes up max ~200px

## Solution 💡

* Use the 2nd image returned by the Spotify albums endpoint, which I _think_ is 300px
  (At the very least it is guaranteed to be a smaller size according to the Spotify docs)

### Also included in this PR

* Reduce data returned from Spotify API to avoid storing unnecessary data

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written
- [x] The full test suite is passing
- [x] There are no TODOs in the code without a very good reason
