### PR TITLE
69 keyval store bug

### DIFF
--- a/cypress/e2e/missingIndexedDBData.cy.js
+++ b/cypress/e2e/missingIndexedDBData.cy.js
@@ -1,0 +1,22 @@
+describe('GIVEN I have the old IndexedDB structure', () => {
+    beforeEach(() => {
+        cy.seedIndexedDbWithOldFormat();
+        cy.visit('/genre-album-map?code=valid_token&state=valid_state');
+    })
+
+    it('THEN the new stores should be created', () => {
+        // Assert that auth and data stores exist
+        cy.window().then((win) => {
+            const request = win.indexedDB.open('spotify-db');
+            request.onsuccess = () => {
+                const db = request.result;
+                expect(db.objectStoreNames.contains('auth')).to.be.true;
+                expect(db.objectStoreNames.contains('data')).to.be.true;
+            };
+          });
+
+        
+        // Assert that the user is redirected to the login page
+        cy.get('.login-button').should('exist');
+    })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,6 +7,14 @@ Cypress.Commands.add('resetIndexedDb', () => {
     cy.getIndexedDb('@spotify-db').createObjectStore('data').as('data');
 });
 
+Cypress.Commands.add('seedIndexedDbWithOldFormat', () => {
+    cy.clearIndexedDb('spotify-db');
+    cy.openIndexedDb('spotify-db').as('spotify-db');
+    cy.getIndexedDb('@spotify-db').createObjectStore('keyval').as('keyval');
+    cy.getStore('@keyval').createItem('groupedAlbums', {});
+    cy.getStore('@keyval').createItem('token', "BQB");
+});
+
 Cypress.Commands.add('setIndexedDbData', (store, key, value) => {
     cy.getStore(`@${store}`).createItem(`${key}`, `${value}`);
 });

--- a/src/utilities/indexedDb.js
+++ b/src/utilities/indexedDb.js
@@ -1,10 +1,13 @@
 import { openDB } from 'idb';
 import logMessage from './loggingConfig';
 
-const dbPromise = openDB('spotify-db', undefined, {
+const dbPromise = openDB('spotify-db', 3, {
   upgrade(db) {
     db.createObjectStore('auth');
     db.createObjectStore('data');
+    if (db.objectStoreNames.contains('keyval')) {
+      db.deleteObjectStore('keyval');
+    }
   },
 });
 

--- a/src/utilities/indexedDb.js
+++ b/src/utilities/indexedDb.js
@@ -2,7 +2,8 @@ import { openDB } from 'idb';
 import logMessage from './loggingConfig';
 
 const dbPromise = openDB('spotify-db', 3, {
-  upgrade(db) {
+  upgrade(db, oldVersion, newVersion, transaction) {
+    logMessage(`Upgrading indexedDb from version ${oldVersion} to ${newVersion}`);
     db.createObjectStore('auth');
     db.createObjectStore('data');
     if (db.objectStoreNames.contains('keyval')) {


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* Old database structrue (keyval instead of auth and data) causes app to crash
* The occurs because the database version was `undefined`, so upgrade function is not run and new data stores are not created

## Solution 💡

* Hard code IndexedDB version (3)
  This means that, if the database stored locally is version 1, `upgrade` will be triggered
* Delete keyval if old found
* Add tests

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written
- [x] The full test suite is passing
- [x] There are no TODOs in the code without a very good reason
