### PR TITLE
Retain search query and add tests

### DIFF
--- a/cypress/e2e/genreCardBehaviour.cy.js
+++ b/cypress/e2e/genreCardBehaviour.cy.js
@@ -3,6 +3,23 @@ describe('GIVEN I am on the genre grid page', () => {
         cy.mockAPIResponsesAndInitialiseAuthenticatedState();
     });
 
+    describe('WHEN I change the search query', () => {
+        beforeEach(() => {
+            cy.get('.search-bar').type('slowcore');
+        });
+
+        it('THEN the genre grid is filtered', () => {
+            cy.get('.genre-section').should('have.length', 1);
+            cy.get('.genre-section').eq(0).should('contain', 'slowcore, spoken word');
+        });
+
+        it('THEN the search query is retained', () => {
+            cy.get('.genre-section').eq(0).click();
+            cy.get('.back-button').click();
+            cy.get('.search-bar').should('have.value', 'slowcore');
+        });
+    });
+    
     describe('WHEN I click on a genre card', () => {
         beforeEach(() => {
             cy.get('.genre-section').eq(0).click();

--- a/src/containers/genreContainer/genreContainer.js
+++ b/src/containers/genreContainer/genreContainer.js
@@ -6,9 +6,9 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { useNavigationHelpers } from "../../utilities/navigationHelpers";
 
-function GenreContainer({ genre, albums, onBack }) {
-    const [searchQuery, setSearchQuery] = useState("");
-    const [sortOption, setSortOption] = useState("alphabetical-asc-artist");
+function GenreContainer({ genre, albums, onBack, searchQuery: initialSearchQuery = "", sortOption: initialSortOption = "alphabetical-asc-artist" }) {
+    const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
+    const [sortOption, setSortOption] = useState(initialSortOption);
     const [selectedAlbum, setSelectedAlbum] = useState(null);
     const { goTo } = useNavigationHelpers();
 

--- a/src/containers/genreGridContainer/genreGridContainer.js
+++ b/src/containers/genreGridContainer/genreGridContainer.js
@@ -17,6 +17,7 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
   const [sortOption, setSortOption] = useState('number-desc');
   const { showBoundary } = useErrorBoundary();
   const [selectedGenre, setSelectedGenre] = useState(null);
+  const [prevSearchQuery, setPrevSearchQuery] = useState(''); // Add a state to store the previous search query
   const { goTo } = useNavigationHelpers();
   const navigate = useNavigate();
 
@@ -28,7 +29,6 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
     if (url.pathname === '/genre-album-map') {
       setSelectedGenre(null);
       setSortOption('number-desc');
-      setSearchQuery('');
     }
   }, [navigate]);
 
@@ -248,15 +248,17 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
   });
 
   const handleGenreClick = (genre, albums) => {
+    setPrevSearchQuery(searchQuery); 
     setSortOption('alphabetical-asc');
     setSelectedGenre({ genre, albums });
+    setSearchQuery(''); 
     goTo(`/genre`, { genre });
   };
 
   const handleBackToGrid = () => {
     setSelectedGenre(null);
     setSortOption('number-desc');
-    setSearchQuery('');
+    setSearchQuery(prevSearchQuery); 
     goTo('/genre-album-map');
   };
 
@@ -291,6 +293,7 @@ const GenreGridContainer = forwardRef((props, genreGridRef) => {
                 : "Search genres, albums, and artists..."
             }
             sortOptions={selectedGenre ? sortOptions.slice(0, 2) : sortOptions}
+            searchQuery={searchQuery} 
           />
           <div className="genre-grid">
             {sortedGenres.map(([genre, albums], index) => (


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* Retain search query when returning back from genre container

## Solution 💡

Slightly janky, but
* Also track a _prevSearchQuery_, which is used to populate the search bar on return

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written
- [x] The full test suite is passing
- [x] There are no TODOs in the code without a very good reason
