### PR TITLE
Add release GitHub action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+name: Tag, Release, and Merge PR from staging to main
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (e.g., v1.2.3)'
+        required: true
+        default: ''
+
+jobs:
+  release-and-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout staging branch
+      uses: actions/checkout@v3
+      with:
+        ref: staging
+        fetch-depth: 0  
+
+    - name: Create tag on staging
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag ${{ github.event.inputs.tag }}
+        git push origin ${{ github.event.inputs.tag }}
+
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ github.event.inputs.tag }}
+        name: Release ${{ github.event.inputs.tag }}
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create Pull Request from staging to main
+      id: create_pr
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        source_branch: staging
+        target_branch: main
+        title: "Merge staging into main for release ${{ github.event.inputs.tag }}"
+        body: "Automated PR to merge staging into main for release ${{ github.event.inputs.tag }}"
+        draft: false
+
+    - name: Merge the pull request
+      uses: peter-evans/pull-request-merge@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
+        merge-method: merge


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* Release process takes too many clicks

## Solution 💡

* Create a GitHub action to automate the process of:
  * Creating a tag and release from `staging`
  * Creating and merging a PR from `staging` to `main`

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written
- [x] The full test suite is passing
- [x] There are no TODOs in the code without a very good reason
