### PR TITLE
59 add tests for token expiry and renewal

### DIFF
--- a/cypress/e2e/authenticatedNavigation.cy.js
+++ b/cypress/e2e/authenticatedNavigation.cy.js
@@ -62,7 +62,7 @@ describe('GIVEN I am on the homepage', () => {
             cy.get('.overlay-menu').click('bottomRight', { force: true });
         });
         
-        it.only('THEN the hamburger menu should stay open', () => {
+        it('THEN the hamburger menu should stay open', () => {
             cy.get('.overlay-menu').should('be.visible');
             cy.get('.overlay-background').should('be.visible');
             cy.get('.close-menu-button').click();

--- a/cypress/e2e/genreCardBehaviour.cy.js
+++ b/cypress/e2e/genreCardBehaviour.cy.js
@@ -17,7 +17,7 @@ describe("GIVEN I have no albums in my library", () => {
     cy.wait(["@authToken", "@getMySavedAlbums_noAlbums"]);
   });
 
-  it.only("THEN the no albums message should be shown", () => {
+  it("THEN the no albums message should be shown", () => {
     cy.get(".page-title").should("contain", "Your album library");
     cy.get(".refresh-button").should("exist");
 

--- a/cypress/fixtures/mockAuthTokenResponse_fastExpiry.json
+++ b/cypress/fixtures/mockAuthTokenResponse_fastExpiry.json
@@ -1,0 +1,5 @@
+{
+  "access_token": "valid_access_token",
+  "expires_in": 0,
+  "refresh_token": "valid_refresh_token"
+}

--- a/cypress/fixtures/mockRefreshTokenResponse.json
+++ b/cypress/fixtures/mockRefreshTokenResponse.json
@@ -1,0 +1,5 @@
+{
+    "access_token": "newAccessToken",
+    "expires_in": 3600,
+    "refresh_token": "newRefreshToken"
+}


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* No tests to verify that the token expiry and renewal process is working

## Solution 💡

* Intercept initial call with a very fast expiry (literally 0 seconds)
* Intercept refresh token call
* Refresh page and verify that the token renewal code is run (by spying on console.log)

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written
- [x] The full test suite is passing
- [x] There are no TODOs in the code without a very good reason
