### PR TITLE
Create budget alerts module in global terraform config

### DIFF
--- a/terraform-global/.terraform.lock.hcl
+++ b/terraform-global/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.99.1"
+  hashes = [
+    "h1:atjIGE0AtiuzUl6VF8ttGpVdQ583uBslxmIn0A/egyA=",
+    "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
+    "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",
+    "zh:2035977ed418dcb18290785c1eeb79b7133b39f718c470346e043ac48887ffc7",
+    "zh:67e3ca1bf7061900f81cf958d5c771a2fd6048c2b185bec7b27978349b173a90",
+    "zh:87fadbe5de7347ede72ad879ff8d8d9334103cd9aa4a321bb086bfac91654944",
+    "zh:901d170c457c2bff244a2282d9de595bdb3ebecc33a2034c5ce8aafbcff66db9",
+    "zh:92c07d6cf530679565b87934f9f98604652d787968cce6a3d24c148479b7e34b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7d4803b4c5ff17f029f8b270c91480442ece27cec7922c38548bcfea2ac2d26",
+    "zh:afda848da7993a07d29018ec25ab6feda652e01d4b22721da570ce4fcc005292",
+    "zh:baaf16c98b81bad070e0908f057a97108ecd6e8c9f754d7a79b18df4c8453279",
+    "zh:c3dd496c5014427599d6b6b1c14c7ebb09a15df78918ae0be935e7bfa83b894c",
+    "zh:e2b84c1d40b3f2c4b1d74bf170b9e932983b61bac0e6dab2e36f5057ddcc997f",
+    "zh:e49c92cb29c53b4573ed4d9c946486e6bcfc1b63f1aee0c79cc7626f3d9add03",
+    "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
+  ]
+}

--- a/terraform-global/main.tf
+++ b/terraform-global/main.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region  = "eu-west-2"
+  profile = "genrebrowser"
+}
+
+terraform {
+  backend "s3" {
+    profile = "genrebrowser"
+    bucket  = "genrebrowser-tf-state"
+    key     = "global/s3/terraform.tfstate"
+    region  = "eu-west-2"
+    encrypt = true
+
+    use_lockfile = true
+  }
+}
+
+# Budget alerts module
+
+variable "email_address" {
+  description = "Email address to send budget alerts to"
+  type        = string
+}
+
+module "budget_alerts" {
+  source = "./modules/budget_alerts"
+
+  monthly_budget_amount = 10
+  email_address         = var.email_address
+}

--- a/terraform-global/modules/budget_alerts/main.tf
+++ b/terraform-global/modules/budget_alerts/main.tf
@@ -1,0 +1,68 @@
+variable "monthly_budget_amount" {
+  description = "The monthly budget amount in USD"
+  type        = number
+}
+
+variable "email_address" {
+  description = "Email address to send budget alerts to"
+  type        = string
+}
+
+variable "alert_thresholds" {
+  description = "List of threshold percentages for budget alerts"
+  type        = list(number)
+  default     = [50, 80, 90, 100]
+}
+
+resource "aws_sns_topic" "budget_alerts" {
+  name = "budget-alerts"
+}
+
+resource "aws_sns_topic_policy" "budget_alerts_policy" {
+  arn    = aws_sns_topic.budget_alerts.arn
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowBudgetsToPublish",
+        Effect    = "Allow",
+        Principal = {
+          Service = "budgets.amazonaws.com"
+        },
+        Action    = "SNS:Publish",
+        Resource  = aws_sns_topic.budget_alerts.arn
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "budget_email" {
+  topic_arn = aws_sns_topic.budget_alerts.arn
+  protocol  = "email"
+  endpoint  = var.email_address
+}
+
+resource "aws_budgets_budget" "monthly" {
+  name              = "monthly-budget"
+  budget_type       = "COST"
+  limit_amount      = tostring(var.monthly_budget_amount)
+  limit_unit        = "USD"
+  time_period_start = "2023-01-01_00:00"
+  time_unit         = "MONTHLY"
+
+  dynamic "notification" {
+    for_each = var.alert_thresholds
+    content {
+      comparison_operator         = "GREATER_THAN"
+      threshold                   = notification.value
+      threshold_type              = "PERCENTAGE"
+      notification_type           = "ACTUAL"
+      subscriber_sns_topic_arns   = [aws_sns_topic.budget_alerts.arn]
+    }
+  }
+}
+
+output "sns_topic_arn" {
+  value       = aws_sns_topic.budget_alerts.arn
+  description = "The ARN of the SNS topic for budget alerts"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,4 +135,3 @@ module "pkce_proxy" {
 output "pkce_proxy_endpoint" {
   value = module.pkce_proxy.api_url
 }
-


### PR DESCRIPTION
# PR Summary

## Problem 🤔

* No budget alerting (or at least minimal)
* Costs could spiral out of control

## Solution 💡

* Create budget alerts module
* SNS topic to send alerts to my email
* Put Terraform config in a new directory `/terraform-global`, since we don't want budget alerts to be affected by workspaces

## PR Review Checklist 📋

<!---We can put Definition of Done type stuff in here if we like--->
<!---e.g 'corresponding tests added', 'no TODOs in the code'--->

- [x] Appropriate logging has been added
- [x] Appropriate tests have been written
- [x] The full test suite is passing
- [x] There are no TODOs in the code without a very good reason
